### PR TITLE
Docs: align spec guidance with GitHub issues

### DIFF
--- a/docs/agents/AGENT_PRIMER_TEMPLATE.md
+++ b/docs/agents/AGENT_PRIMER_TEMPLATE.md
@@ -31,7 +31,7 @@ Use this skeleton to create new agent primers. Keep it concise, explicit, and en
 
 ## Output and Handoff
 - Artifacts to produce (reports, specs, comments), required tags (e.g., “Ready for IMPLEMENTATION_START”).
-- File locations (e.g., `docs/specs/`, `docs/reports/`).
+- File locations (e.g., `docs/contracts/`, `docs/reports/`).
 - Links to relevant status/pillar lines used.
 
 ## Constraints

--- a/docs/agents/DESIGN_SPEC_START.md
+++ b/docs/agents/DESIGN_SPEC_START.md
@@ -37,7 +37,7 @@ Use `{{CONTRIBUTING_DOC}}` template. Keep terse:
 - Extend existing systems (new systems require approval)
 - Don't modify tests without approval
 - Avoid autoloads unless requested/approved
-- Align with `{{DOCUMENTATION_POLICY_DOC}}`: Lean specs, store large specs in `docs/specs/` when requested
+- Align with `{{DOCUMENTATION_POLICY_DOC}}`: Lean specs live in GitHub Epics + child Issues unless a project explicitly requests local spec files
 
 ## Handoff to Implementation
 
@@ -46,7 +46,7 @@ Tag: `Ready for IMPLEMENTATION_START`
 Include:
 - Links to exact GitHub issues/PRs + pillar sections used
 - Test intent: Automated scenarios + manual checklist (if any)
-- Spec file location (if created): `docs/specs/`
+- Spec location: GitHub Epics + child Issues
 
 ## Quick Checklist
 

--- a/docs/agents/IMPLEMENTATION_START.md
+++ b/docs/agents/IMPLEMENTATION_START.md
@@ -526,7 +526,7 @@ Replace these placeholders with your project specifics:
 - `{{MAIN_BRANCH}}` → "main", "master", "develop"
 - `{{PROJECT_DOMAIN}}` → "example.com", "yourproject.dev"
 - `{{GITHUB_QUERIES_DOC}}` → ".aide/docs/agents/GITHUB_QUERIES.md" (reference for querying implementation status)
-- `{{PROJECT_DESIGN_DOCS}}` → "design/", "docs/specs/", "docs/adr/"
+- `{{PROJECT_DESIGN_DOCS}}` → "design/", "docs/adr/"
 - `{{DEVELOPMENT_DOC}}` → "docs/DEVELOPMENT.md", "docs/ARCHITECTURE.md"
 - `{{CODING_GUIDELINES_DOC}}` → "docs/CODING_GUIDELINES.md"
 - `{{TESTING_POLICY_DOC}}` → "docs/TESTING_POLICY.md"

--- a/docs/core/CONTRIBUTING.md
+++ b/docs/core/CONTRIBUTING.md
@@ -78,7 +78,7 @@ All PRs require review before merging. See [agents/PR_REVIEW_START.md](../agents
 - Implementation approach: brief outline (systems touched, data/flows, tests to add)
 - Impacted files: key modules/components/scripts
 
-Keep specs in PR/commit descriptions or a short note; create `{{SPECS_DIRECTORY}}/<feature>.md` only for bigger features when requested.
+Specs live in GitHub Epics + child Issues. PR descriptions summarize the implementation approach and link to the issue.
 
 ## Testing Requirements
 
@@ -97,6 +97,7 @@ See [DOCUMENTATION_POLICY.md](DOCUMENTATION_POLICY.md) for complete documentatio
 - Update relevant docs when behavior changes (README, {{DEVELOPMENT_DOC}}, design docs)
 - Avoid duplicating information across files; use references
 - Only create new spec files when explicitly requested
+- System invariants live in {{CONTRACTS_DIRECTORY}} (if used); avoid restating them elsewhere
 
 ## Code Standards
 
@@ -132,5 +133,5 @@ Replace these placeholders:
 - `{{LANGUAGE}}` → `TypeScript`, `Python`, `Rust`, `GDScript`
 - `{{FRAMEWORK}}` → `React`, `Django`, `Actix`, `Godot`
 - `{{DEVELOPMENT_DOC}}` → `docs/DEVELOPMENT.md`, `docs/ARCHITECTURE.md`
-- `{{SPECS_DIRECTORY}}` → `docs/specs/`, `docs/rfcs/`, `docs/adr/`
-- `{{PROJECT_DESIGN_DOCS}}` → `docs/design/`, `docs/specs/`, `docs/architecture/`
+- `{{CONTRACTS_DIRECTORY}}` → `docs/contracts/`
+- `{{PROJECT_DESIGN_DOCS}}` → `docs/design/`, `docs/architecture/`

--- a/docs/core/DOCUMENTATION_POLICY.md
+++ b/docs/core/DOCUMENTATION_POLICY.md
@@ -7,10 +7,11 @@ Keep docs lean, consistent, and authoritative.
 Define your project's documentation hierarchy:
 
 - **README.md**: User/player-facing basics (install, run, key features)
+- **GitHub Epics + child Issues**: Specs and implementation state
 - **{{PROJECT_SUMMARY_DOC}}**: High-level project overview and current state
 - **{{DEVELOPMENT_DOC}}**: Architecture and how to extend/debug
 - **{{CONTRIBUTING_DOC}}**: Workflow, specs, testing, review process
-- **{{SPECS_DIRECTORY}}**: Feature or debugging specs for larger changes
+- **{{CONTRACTS_DIRECTORY}}**: System invariants/contracts (project-level, optional)
 
 Customize this list to match your project's structure.
 
@@ -33,7 +34,7 @@ A formal `CHANGELOG.md` is optional and should be added when preparing for publi
 
 ## Adding/Editing Docs
 
-- Add a brief feature summary and implementation approach in specs/PRs before coding
+- Add a brief feature summary and implementation approach in GitHub issues/PRs before coding
 - Prefer links/references to existing sections instead of copy/pasting content
 - Note known gaps or future work where applicable
 
@@ -93,6 +94,6 @@ Replace these placeholders with your actual documentation structure:
 - `{{PROJECT_SUMMARY_DOC}}` → `docs/PROJECT_SUMMARY.md` or `docs/OVERVIEW.md`
 - `{{DEVELOPMENT_DOC}}` → `docs/DEVELOPMENT.md` or `docs/ARCHITECTURE.md`
 - `{{CONTRIBUTING_DOC}}` → `docs/CONTRIBUTING.md` or `CONTRIBUTING.md`
-- `{{SPECS_DIRECTORY}}` → `docs/specs/`, `docs/rfcs/`, `docs/adr/`
+- `{{CONTRACTS_DIRECTORY}}` → `docs/contracts/`
 - `{{IMPLEMENTATION_STATUS_QUERY}}` → `gh issue list --label "status:in-progress"` (see [GITHUB_QUERIES.md](../agents/GITHUB_QUERIES.md))
-- `{{PROJECT_DESIGN_DOCS}}` → `docs/design/`, `docs/specs/`, `docs/architecture/`
+- `{{PROJECT_DESIGN_DOCS}}` → `docs/design/`, `docs/architecture/`

--- a/docs/standards/CODING_GUIDELINES.template.md
+++ b/docs/standards/CODING_GUIDELINES.template.md
@@ -103,5 +103,5 @@ Replace these placeholders:
 - `{{STYLE_GUIDE_NAME}}` → "Airbnb JavaScript Style Guide", "PEP 8", "Rust Book"
 - `{{STYLE_GUIDE_LINK}}` → URL to official style guide
 - `{{DEVELOPMENT_DOC}}` → "docs/DEVELOPMENT.md", "docs/ARCHITECTURE.md"
-- `{{PROJECT_DESIGN_DOCS}}` → "docs/design/", "docs/specs/"
+- `{{PROJECT_DESIGN_DOCS}}` → "docs/design/", "docs/architecture/"
 - `{{DOMAIN_SPECIFIC_GUIDANCE}}` → Guidance specific to your domain (web, game, CLI, etc.)

--- a/docs/standards/DEVELOPMENT.template.md
+++ b/docs/standards/DEVELOPMENT.template.md
@@ -66,4 +66,4 @@ Replace these placeholders:
 - `{{Component Type 1/2/3}}` → Your architecture's main components
 - `{{Component Name 1/2/3}}` → Specific key components in your project
 - `{{Domain}}` → "Web", "Game", "CLI", "Mobile", "Backend"
-- `{{PROJECT_DESIGN_DOCS}}` → "docs/design/", "docs/specs/"
+- `{{PROJECT_DESIGN_DOCS}}` → "docs/design/", "docs/architecture/"


### PR DESCRIPTION
## Summary
Remove docs/specs references, align spec guidance with GitHub Epics + child Issues, and add docs/contracts for invariants.

## Context
Supports LightbornExileDivinityEngine#171 (AIDE authority consolidation).

## Changes
- Update core Documentation Policy and Contributing docs
- Update agent/standard templates to remove docs/specs references

## Testing
- N/A (docs-only)

---
⚙️ Codex Implementation