### PR TITLE
Add canonical agent orientation entry

### DIFF
--- a/AGENT_ORIENTATION.md
+++ b/AGENT_ORIENTATION.md
@@ -1,0 +1,89 @@
+# AIDE Agent Orientation
+
+**AIDE** — AI-Assisted Development Environment. A universal framework for structured AI-human software collaboration.
+
+---
+
+## Agent Roles
+
+| Role | Purpose | Primer |
+|------|---------|--------|
+| **Implementation** | Build features, fix bugs | [IMPLEMENTATION_START.md](docs/agents/IMPLEMENTATION_START.md) |
+| **PR Review** | Review code quality, architecture | [PR_REVIEW_START.md](docs/agents/PR_REVIEW_START.md) |
+| **Codebase Review** | Holistic health audits | [CODEBASE_REVIEW_START.md](docs/agents/CODEBASE_REVIEW_START.md) |
+| **Design Spec** | Prioritize and spec features | [DESIGN_SPEC_START.md](docs/agents/DESIGN_SPEC_START.md) |
+| **Design Workshop** | High-level design exploration | [DESIGN_WORKSHOP_START.md](docs/agents/DESIGN_WORKSHOP_START.md) |
+| **Doc Review** | Documentation accuracy | [DOC_REVIEW_START.md](docs/agents/DOC_REVIEW_START.md) |
+
+---
+
+## Document Authority Hierarchy
+
+### Tier 1: Authoritative (Binding)
+Project-side documents satisfy AIDE contracts. Agents MUST read project's authority mapping first.
+
+| Expectation | Project Must Provide |
+|-------------|---------------------|
+| Placeholder mappings | `AGENTS.md` or equivalent with `{{PLACEHOLDER}}` → value table |
+| Code style rules | `{{CODING_GUIDELINES_DOC}}` |
+| Test requirements | `{{TESTING_POLICY_DOC}}` |
+| Workflow rules | `{{CONTRIBUTING_DOC}}` |
+
+### Tier 2: Framework Reference (AIDE)
+AIDE provides workflow structure. Projects customize via placeholder mappings.
+
+| Document | Purpose |
+|----------|---------|
+| [docs/agents/*.md](docs/agents/) | Role-specific workflow primers |
+| [docs/core/*.md](docs/core/) | Process templates |
+| [AGENT_OPERATIONAL_TOKEN_ECONOMY.md](docs/agents/AGENT_OPERATIONAL_TOKEN_ECONOMY.md) | Efficiency guidelines |
+
+### Tier 3: Examples (Non-Binding)
+Reference implementations. Copy and customize, do not follow directly.
+
+| Path | Purpose |
+|------|---------|
+| [docs/examples/](docs/examples/) | Tech-stack-specific templates |
+
+---
+
+## Workflow Stages (Implementation)
+
+```
+0. Spec Intake      → Get issue/spec, extract goals
+1. Codebase Survey  → Read targeted, NO CODING
+2. Plan + Draft PR  → Get approval, create branch
+3. Implement        → Code + tests, clean commits
+4. Sanity Check     → Verify success criteria
+5. Refinement       → Cleanup, best practices
+6. PR Ready         → Mark for review
+7. Report Back      → Summarize vs spec
+8. Address Feedback → Fix review issues
+9. Merge            → After approval
+10. Sync Main       → Update local
+```
+
+---
+
+## Entry Workflow
+
+1. **Project provides orientation** → Read project's `AGENT_ORIENTATION.md` or `AGENTS.md`
+2. **Resolve placeholders** → Map `{{PLACEHOLDERS}}` using project's table
+3. **Load role primer** → Read appropriate primer from `docs/agents/`
+4. **Execute workflow** → Follow primer end-to-end
+
+---
+
+## Required Project Contracts
+
+Projects using AIDE MUST provide:
+
+- [ ] Placeholder mapping table (all `{{PLACEHOLDERS}}` resolved)
+- [ ] Document authority hierarchy (what is binding vs reference)
+- [ ] Test commands and policy
+- [ ] Code style rules
+- [ ] Contribution workflow
+
+---
+
+*This document defines AIDE expectations. Projects satisfy them via explicit mappings.*

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # AIDE: AI-Assisted Development Environment
 
+> **AI Agents:** Start with [AGENT_ORIENTATION.md](AGENT_ORIENTATION.md) for roles, authority hierarchy, and entry workflow.
+
 **A universal framework for AI-assisted software development workflows.**
 
 AIDE provides battle-tested processes, agent primers, and documentation templates for teams building software with AI assistance. Language-agnostic, framework-agnostic, and adaptable to any project type.


### PR DESCRIPTION
## Summary
- Create `AGENT_ORIENTATION.md` as canonical agent entry point (~400 words, ~540 tokens)
- Define agent roles with primer references in table format
- Establish 3-tier document authority hierarchy (binding/reference/examples)
- List workflow stages and entry workflow
- Specify required project contracts that AIDE expects

## Alignment with Epic #2
This addresses the first child issue of the AI Orientation & Primer Modularization epic:
- Provides single, authoritative entry point for AIDE-driven workflows
- Removes ambiguity about which documents to read first
- Bounded for default context loading

## Test Plan
- [ ] Verify `AGENT_ORIENTATION.md` exists at AIDE root
- [ ] Confirm all primer links resolve correctly
- [ ] Verify README.md references orientation document
- [ ] Confirm document is concise (<600 tokens)

Resolves #3

---
Generated with [Claude Code](https://claude.com/claude-code)