### PR TITLE
Consolidate and de-duplicate workflow guidance (fixes #7)

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -208,7 +208,7 @@ git commit -m "Add AIDE framework for AI-assisted development
 - Set up GitHub state tracking labels
 
 Framework provides:
-- 7-step implementation workflow
+- Implementation workflow (Steps 0-10)
 - PR review process
 - Documentation standards
 - Testing policy"
@@ -221,12 +221,12 @@ Once setup is complete, share this with your AI assistant:
 ```
 I've integrated the AIDE framework into this project. Please read:
 
-1. docs/agents/IMPLEMENTATION_START.md - For implementing features
+1. docs/agents/IMPLEMENTATION_START.md - For implementing features (index)
 2. docs/agents/PR_REVIEW_START.md - For reviewing PRs
 3. Query GitHub for current state: gh issue list --label "status:in-progress"
 4. docs/CONTRIBUTING.md - Our workflow
 
-Follow the 9-step implementation workflow for all changes.
+Follow the implementation workflow (Steps 0-10) for all changes.
 ```
 
 ## Verification Checklist
@@ -300,7 +300,7 @@ git submodule update --remote .aide
 
 ## Next Steps
 
-1. **Read the 7-Step Workflow**: [docs/agents/IMPLEMENTATION_START.md](docs/agents/IMPLEMENTATION_START.md)
+1. **Read the implementation workflow index**: [docs/agents/IMPLEMENTATION_START.md](docs/agents/IMPLEMENTATION_START.md)
 2. **Start Your First Feature**: Follow the workflow with your AI agent
 3. **Review Your First PR**: Use [docs/agents/PR_REVIEW_START.md](docs/agents/PR_REVIEW_START.md)
 4. **Customize Further**: Adapt templates to your team's needs
@@ -314,7 +314,7 @@ git submodule update --remote .aide
 ## Tips for Success
 
 ### Do:
-✅ Follow the 9-step workflow consistently
+✅ Follow the implementation workflow consistently
 ✅ Update GitHub issues/PRs after every merge (mark issues completed, update epic progress)
 ✅ Use agent primers to guide AI behavior
 ✅ Customize templates to fit your team's style

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ All changes require tests. No exceptions (unless you document why).
 
 AIDE defines specialized AI agent roles:
 
-- **Implementation Agent**: Builds features following the 7-step workflow
+- **Implementation Agent**: Builds features following the implementation workflow (Steps 0-10)
 - **PR Review Agent**: Reviews code for quality, architecture, and standards
 - **Documentation Agent**: Reviews docs for accuracy and consistency
 - **Codebase Review Agent**: Performs holistic codebase audits
@@ -162,17 +162,14 @@ Each role has a dedicated primer in `docs/agents/`.
 
 **Token Optimization**: All agent primers follow token economy best practices (see `docs/agents/AGENT_TOKEN_ECONOMY.md`) to maximize context budget for code analysis and implementation. Target 150-500 tokens per primer depending on complexity.
 
-## The 7-Step Implementation Workflow
+## Implementation Workflow (Canonical)
 
-1. **Codebase Survey** - Understand current state (no coding yet)
-2. **Implementation Plan** - Design approach, get approval
-3. **Git-First Development** - Branch, draft PR, clean commits
-4. **Testing** - Automated tests, manual verification
-5. **Sanity Check** - Edge cases, gameplay/user testing
-6. **PR Ready** - Complete scope, passing tests, docs updated
-7. **Review & Merge** - Feedback loop, merge on approval
+The canonical implementation workflow lives in the Implementation Agent primer index:
 
-See [docs/agents/IMPLEMENTATION_START.md](docs/agents/IMPLEMENTATION_START.md) for full details.
+- [docs/agents/IMPLEMENTATION_START.md](docs/agents/IMPLEMENTATION_START.md) (index)
+- [docs/agents/implementation/](docs/agents/implementation/) (stage-scoped step docs)
+
+To avoid duplication and drift, this README does not restate the step-by-step instructions.
 
 ## Philosophy
 
@@ -188,7 +185,7 @@ AIDE emerged from real-world experience building software with AI agents. Key in
 
 ### Lightborn Exile: Divinity Engine (Godot/GDScript)
 A roguelike factory survival game built entirely with AI-assisted development using AIDE workflows. Demonstrates:
-- 7-step implementation workflow
+- Implementation workflow (Steps 0-10)
 - PR review process with inline comments
 - Documentation review and accuracy checks
 - Design workshop for feature planning

--- a/docs/core/CONTRIBUTING.md
+++ b/docs/core/CONTRIBUTING.md
@@ -4,12 +4,11 @@ Minimal, repeatable workflow to keep changes consistent and documented.
 
 ## Official Workflow
 
-**All contributors and agents must follow the 7-Step Workflow documented in [agents/IMPLEMENTATION_START.md](../agents/IMPLEMENTATION_START.md).**
+**All contributors and agents must follow the implementation workflow (Steps 0-10) documented in [agents/IMPLEMENTATION_START.md](../agents/IMPLEMENTATION_START.md).**
 
-The workflow ensures consistent, reviewable changes:
-1. Codebase Survey → 2. Implementation Plan → 3. Git-First Development → 4. Sanity Check → 5. PR Draft → 6. Update Docs → 7. Report Back
+To reduce duplication and drift, this file does not restate the step-by-step workflow. Use the primer index as the single source of truth, and load only the step document for the stage you are currently executing.
 
-See [agents/IMPLEMENTATION_START.md](../agents/IMPLEMENTATION_START.md) for complete details.
+See [agents/IMPLEMENTATION_START.md](../agents/IMPLEMENTATION_START.md) (index) and [agents/implementation/](../agents/implementation/) (step docs) for complete details.
 
 ---
 
@@ -113,7 +112,7 @@ See [CODING_GUIDELINES.md](CODING_GUIDELINES.md) for complete coding standards.
 ## Reference Documentation
 
 **Workflow & Process:**
-- [agents/IMPLEMENTATION_START.md](../agents/IMPLEMENTATION_START.md) - 7-Step implementation workflow
+- [agents/IMPLEMENTATION_START.md](../agents/IMPLEMENTATION_START.md) - Implementation workflow (index)
 - [agents/PR_REVIEW_START.md](../agents/PR_REVIEW_START.md) - PR review workflow
 - [TESTING_POLICY.md](TESTING_POLICY.md) - Testing requirements and standards
 - [DOCUMENTATION_POLICY.md](DOCUMENTATION_POLICY.md) - Documentation standards


### PR DESCRIPTION
## Summary
Reduce duplicated/conflicting workflow guidance by referencing a single canonical workflow source and aligning terminology.

Fixes #7

## Implementation Plan
- [x] Identify duplicate workflow step descriptions across docs
- [x] Choose canonical source for implementation workflow (keep as single source of truth)
- [x] Replace redundant step lists with references to the canonical doc
- [x] Align terminology and step naming across docs (no workflow redesign)
- [x] Self-review for conflicts and broken links

## Testing
N/A (documentation-only)

## Files Changed
- `README.md`
- `QUICK_START.md`
- `docs/core/CONTRIBUTING.md`