### PR TITLE
Establish token budget guidelines for agent docs (fixes #8)

### DIFF
--- a/docs/agents/AGENT_PRIMER_TEMPLATE.md
+++ b/docs/agents/AGENT_PRIMER_TEMPLATE.md
@@ -52,7 +52,8 @@ Use this skeleton to create new agent primers. Keep it concise, explicit, and en
   - Reference authoritative docs instead of duplicating content
   - Front-load critical constraints
   - One clear example > multiple redundant ones
-  - Target 150-500 tokens depending on agent complexity
+  - Use token budgets by doc type (see "Token Budget Guidelines (By Document Type)")
+  - Target 150-500 tokens for role primers depending on agent complexity
 
 ## Signature/Attribution (if required)
 - Commit trailer or review prefix format.

--- a/docs/agents/AGENT_TOKEN_ECONOMY.md
+++ b/docs/agents/AGENT_TOKEN_ECONOMY.md
@@ -200,6 +200,29 @@ When creating or updating agent primer files:
 
 ## Measuring Token Efficiency
 
+## Token Budget Guidelines (By Document Type)
+
+Token efficiency is a design constraint. Keep default-loaded context small and predictable by budgeting *agent-facing documentation* by type.
+
+**Recommended budgets:**
+
+| Document Type | Load Mode | Target Size | Guidance |
+|--------------|----------|-------------|----------|
+| Project `AGENTS.md` / `AGENT_ORIENTATION.md` | Always-loaded | 300-800 tokens | Include only binding contracts, placeholder mappings, and entry workflow. Avoid deep references. |
+| Framework `AGENT_ORIENTATION.md` | Always-loaded | 200-600 tokens | Roles, authority tiers, entry workflow, doc loading policy. No deep templates. |
+| Role primer index (`*_START.md`) | Stage-loaded | 200-500 tokens | Index + workflow map + links to step docs; avoid repeating step content. |
+| Stage step docs (Step 0, Step 1, ...) | Stage-loaded | 250-700 tokens each | Purpose/prereqs/actions/exit criteria. Keep examples minimal. |
+| Reference docs | Reference-only | No strict limit | Add a short "Summary (Non-Authoritative)" <= 150-250 tokens at top; full depth below. |
+
+**Measurement heuristics (no tooling required):**
+- Rough conversion: 1 token ~= 0.75 words (English prose); tables/code can skew higher.
+- Quick sanity check: 500 tokens is often ~1 page of bullets.
+
+**Red flags:**
+- Always-loaded docs growing into "how to do everything" guides
+- Role primer index repeating the full step content
+- Reference docs that must be read to execute Step 0/1/2
+
 **Target token budgets by agent type:**
 - **Implementation agents:** 300-500 tokens (complex workflows)
 - **Review agents:** 200-400 tokens (structured evaluation)


### PR DESCRIPTION
## Summary
Establish recommended token budgets for agent-facing docs (orientation, stage primers, reference docs) so contributors keep default context small and predictable.

Fixes #8

## Implementation Plan
- [x] Add explicit token budget guidance by document type (orientation, stage primer index, stage step docs, reference docs)
- [x] Provide measurement heuristics (approx word-count guidance) without adding enforcement tooling
- [x] Update primer template to reference the budgets for new docs

## Testing
N/A (documentation-only)

## Files Changed
- `docs/agents/AGENT_TOKEN_ECONOMY.md`
- `docs/agents/AGENT_PRIMER_TEMPLATE.md`