### PR TITLE
Migrate to unified agent-agnostic skills system

### DIFF
--- a/.github/workflows/codex-skills.yml
+++ b/.github/workflows/codex-skills.yml
@@ -17,17 +17,17 @@ jobs:
 
       - name: Package skills
         shell: pwsh
-        run: ./tools/codex-skills/scripts/package_all.ps1
+        run: ./skills/package-codex.ps1
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
           name: codex-skills
-          path: tools/codex-skills/dist/*.skill
+          path: skills/dist/*.skill
 
       - name: Upload release assets
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          files: tools/codex-skills/dist/*.skill
+          files: skills/dist/*.skill
 

--- a/skills/MIGRATION.md
+++ b/skills/MIGRATION.md
@@ -1,0 +1,188 @@
+# Migration: Codex Skills → Unified AIDE Skills
+
+## Old Structure (Deprecated)
+
+```
+.aide/tools/codex-skills/
+├── src/
+│   ├── aide-prime/
+│   │   ├── SKILL.md
+│   │   ├── scripts/prime.ps1
+│   │   └── references/README.md
+│   ├── aide-quality/
+│   └── ...
+├── dist/               # Generated .skill packages
+├── scripts/
+│   └── package_all.ps1
+└── README.md
+```
+
+**Issues:**
+- Codex-specific (not usable with Claude Code, Cursor, etc.)
+- Separate from unified AIDE skills location
+- Duplication with Claude Code skills
+- Packaging script tightly coupled to Codex
+
+## New Structure (Unified)
+
+```
+.aide/skills/
+├── prime/
+│   ├── SKILL.md        # Agent-agnostic skill definition
+│   └── scripts/        # Optional: tool-specific helpers
+├── quality/
+│   └── SKILL.md
+├── handoff/
+│   └── SKILL.md
+├── plan/
+│   └── SKILL.md
+├── evolve/
+│   └── SKILL.md
+├── dist/               # Generated packages (gitignored)
+├── install-claude.ps1  # Install for Claude Code
+├── package-codex.ps1   # Package for Codex
+└── README.md           # Installation docs
+```
+
+**Benefits:**
+- **Single source of truth** - One skill definition works across tools
+- **Easy distribution** - Scripts handle tool-specific formatting
+- **Maintainable** - Update once, distribute to all tools
+- **Version controlled** - Skills in repo, not user config
+
+## Migration Steps
+
+### Step 1: Copy Skills to New Location
+
+```bash
+# Already done - skills copied from ~/.claude/skills/ to .aide/skills/
+```
+
+### Step 2: Verify Skills Work
+
+```bash
+# Test Claude Code installation
+.aide/skills/install-claude.ps1
+
+# Test Codex packaging
+.aide/skills/package-codex.ps1
+```
+
+### Step 3: Update CI Workflow
+
+Replace `.github/workflows/codex-skills.yml` reference:
+
+**Old:**
+```yaml
+run: ./tools/codex-skills/scripts/package_all.ps1
+path: tools/codex-skills/dist/*.skill
+```
+
+**New:**
+```yaml
+run: ./.aide/skills/package-codex.ps1
+path: .aide/skills/dist/*.skill
+```
+
+### Step 4: Deprecate Old Location
+
+Add deprecation notice to `tools/codex-skills/README.md`:
+
+```markdown
+# DEPRECATED
+
+This directory is deprecated. Skills have moved to `.aide/skills/`.
+
+See: [.aide/skills/README.md](../../.aide/skills/README.md)
+```
+
+### Step 5: Update Documentation
+
+- Update COMMAND_CATALOG.md to reference `.aide/skills/`
+- Update AGENT_ORIENTATION.md with new skill installation instructions
+- Update project README with skill links
+
+## Compatibility
+
+### Codex Users
+
+**Before:**
+- Download `.skill` from GitHub Releases
+- Import via Codex UI
+
+**After:**
+- Same process! `.skill` files generated from unified source
+- OR: Clone repo and run `.aide/skills/install-codex.ps1` (future enhancement)
+
+### Claude Code Users
+
+**Before:**
+- No official skills (manual copy or custom)
+
+**After:**
+- Run `.aide/skills/install-claude.ps1`
+- Skills install to `~/.claude/skills/`
+- Auto-discovered by extension
+
+### Other Tools (Cursor, Windsurf)
+
+**Before:**
+- Not supported
+
+**After:**
+- Check tool docs for skill installation
+- Most support `SKILL.md` format
+- May need tool-specific install script
+
+## Rollout Plan
+
+### Phase 1: Parallel Support (Current)
+- Keep both `.aide/tools/codex-skills/` and `.aide/skills/`
+- Generate Codex packages from new location
+- Test with multiple tools
+
+### Phase 2: Deprecation Notice
+- Add warnings to old location
+- Update all docs to reference new location
+- Keep old location functional
+
+### Phase 3: Full Migration
+- Remove `.aide/tools/codex-skills/src/` (keep only as archive)
+- All packaging from `.aide/skills/`
+- Single source of truth established
+
+## Tool-Specific Notes
+
+### Scripts Directory
+
+Some skills have a `scripts/` subdirectory with PowerShell files:
+- **Codex:** May execute these scripts (needs verification)
+- **Claude Code:** Ignores scripts, uses only SKILL.md instructions
+- **Decision:** Keep scripts for backward compatibility, mark as optional
+
+### YAML Frontmatter
+
+All tools support the format:
+```markdown
+---
+name: skill-name
+description: Brief description
+---
+```
+
+This is the common denominator and should be mandatory.
+
+### References Directory
+
+Old Codex skills had `references/README.md`:
+- Not used by Claude Code
+- Can be removed or moved to comments in SKILL.md
+
+## Testing Checklist
+
+- [ ] Claude Code: Install script works, skills appear in `/` menu
+- [ ] Codex: Package script works, `.skill` imports successfully
+- [ ] CI: Workflow packages and uploads to releases
+- [ ] Docs: README.md has clear install instructions for each tool
+- [ ] Migration: Old location marked deprecated
+- [ ] Skills work identically across tools

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,159 @@
+# AIDE Skills (Agent-Agnostic)
+
+This directory contains AIDE skills in a **tool-agnostic format** compatible with multiple AI coding assistants.
+
+## Supported Tools
+
+- **Claude Code** (VS Code Extension & CLI)
+- **Codex** (VS Code Extension)
+- **Cursor** (with AIDE plugin)
+- **Windsurf** (with skill support)
+
+## Skill Format
+
+Each skill is a directory with a `SKILL.md` file:
+
+```
+skills/
+├── prime/
+│   ├── SKILL.md          # Skill definition (YAML + markdown)
+│   └── scripts/          # Optional: tool-specific automation
+├── quality/
+│   └── SKILL.md
+...
+```
+
+### SKILL.md Format
+
+```markdown
+---
+name: skill-name
+description: Brief description of what this skill does
+---
+
+# Skill Title
+
+Detailed instructions for the AI agent...
+```
+
+The YAML frontmatter is **required**. The markdown content provides instructions.
+
+## Installation
+
+### Claude Code (VS Code Extension or CLI)
+
+**Option 1: Symlink (recommended - stays in sync)**
+```bash
+# Windows (PowerShell as Admin)
+New-Item -ItemType SymbolicLink -Path "$HOME\.claude\skills\prime" -Target "path\to\.aide\skills\prime"
+
+# Linux/Mac
+ln -s /path/to/.aide/skills/prime ~/.claude/skills/prime
+```
+
+**Option 2: Copy**
+```bash
+# Windows
+xcopy /E /I .aide\skills\prime %USERPROFILE%\.claude\skills\prime
+
+# Linux/Mac
+cp -r .aide/skills/prime ~/.claude/skills/prime
+```
+
+**Option 3: Install Script**
+```bash
+# From repo root
+.aide/skills/install-claude.ps1    # Windows
+.aide/skills/install-claude.sh     # Linux/Mac
+```
+
+### Codex (VS Code Extension)
+
+Codex requires packaged `.skill` files (zip archives). Use the packaging script:
+
+```bash
+# From repo root
+.aide/skills/package-codex.ps1
+
+# Generates .aide/skills/dist/*.skill files
+# Import via Codex extension UI: "Import Skill"
+```
+
+### Cursor / Windsurf
+
+Check tool documentation for skill installation. Most support the same `SKILL.md` format.
+
+## Available Skills
+
+| Skill | Command | Description |
+|-------|---------|-------------|
+| **prime** | `/prime` | Load AGENT_ORIENTATION.md and AGENTS.md, extract constraints |
+| **quality** | `/quality` | Run lint and tests from AGENTS.md placeholders |
+| **handoff** | `/handoff` | Generate session handoff note for context resets |
+| **plan** | `/plan` | Create two-layer implementation plan + PR draft |
+| **evolve** | `/evolve` | Turn repeated failures into rules/automation |
+| **role** | `/role` | Route to correct AIDE workflow primer |
+| **sync** | `/sync` | End-of-session git sync (pull, push, verify) |
+| **issue** | `/issue` | Create labeled GitHub issue |
+| **pr-ready** | `/pr-ready` | Validate and mark PR ready |
+
+## Development
+
+### Adding a New Skill
+
+1. Create directory: `.aide/skills/my-skill/`
+2. Create `SKILL.md` with YAML frontmatter + instructions
+3. Test in your preferred tool
+4. Run install/package scripts to distribute
+5. Update this README
+
+### Skill Design Principles
+
+From `COMMAND_CATALOG.md`:
+- **Reduce "agent parses prose" variability** - Clear, structured instructions
+- **Keep default context lean** - Link to docs, don't preload everything
+- **Respect project Tier 1 rules** - Always read AGENTS.md
+- **Be composable** - Small commands that chain together
+
+### Syncing with Codex Skills
+
+The `.aide/tools/codex-skills/` directory is the **old location** for Codex-specific packaging. It will be deprecated in favor of this unified structure.
+
+**Migration plan:**
+1. Use `.aide/skills/` as single source of truth
+2. Generate Codex packages from `.aide/skills/` via script
+3. Remove `.aide/tools/codex-skills/src/` duplicates
+
+## Distribution
+
+### For AIDE Framework Users
+
+Skills are included in the AIDE framework. After cloning:
+
+```bash
+git clone https://github.com/YourOrg/AIDE .aide
+cd .aide
+./skills/install-claude.ps1    # or install-codex.ps1, etc.
+```
+
+### For Standalone Use
+
+Individual skills can be shared by copying the skill directory:
+
+```bash
+# Share prime skill
+cp -r .aide/skills/prime ~/shared-skills/
+# Recipient installs to their tool's skills directory
+```
+
+### Via GitHub Releases
+
+Packaged skills (`.skill` zips for Codex, etc.) are attached to AIDE releases:
+
+1. Go to [AIDE Releases](https://github.com/YourOrg/AIDE/releases)
+2. Download desired `.skill` files
+3. Import via tool's UI
+
+## License
+
+Same as AIDE framework (specify license here)

--- a/skills/dist/.gitignore
+++ b/skills/dist/.gitignore
@@ -1,0 +1,2 @@
+*.skill
+!.gitignore

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: evolve
+description: Apply the AIDE system evolution workflow to repeated mistakes. Reads SYSTEM_EVOLUTION.md and outputs a concrete proposal for turning failures into rules or automation.
+---
+
+# AIDE Evolve
+
+Turn repeated mistakes into system improvements (constraints, docs, automation).
+
+## Workflow
+
+### 1. Locate repo root
+Walk up from current directory until you find `AGENTS.md`.
+
+### 2. Read the evolution guide
+Read `.aide/docs/agents/SYSTEM_EVOLUTION.md` for the decision tree and trigger criteria.
+
+### 3. Collect failure pattern inputs
+Ask the user for:
+- **What happened?** (Describe the failure/mistake)
+- **How many times?** (Must be 2+ occurrences across sessions/PRs)
+- **Evidence:** (PR/issue links or brief excerpts showing the pattern)
+- **Where should it have been caught?** (Tooling? Docs? Invariant?)
+
+### 4. Apply decision tree
+Use this hierarchy (smallest effective change):
+
+**1. Can it be automated?**
+- Is it enforceable by tooling (lint, validator, CI check)?
+- If YES → Propose automation (scripts, CI, pre-commit hook)
+
+**2. Is it project-wide binding?**
+- Does it apply to ALL code/features?
+- Is violating it a critical error?
+- If YES → Tier 1 constraint (AGENTS.md)
+
+**3. Is it system-specific guidance?**
+- Does it apply to a specific subsystem/pattern?
+- Is it helpful but not critical?
+- If YES → Tier 2 guidance (docs/[system].md)
+
+**4. Is it informational only?**
+- Is it a best practice but not enforceable?
+- If YES → Reference-only (docs/reference/ or comments)
+
+### 5. Output concrete proposal
+```markdown
+## System Evolution Proposal
+
+### Failure Pattern
+**What:** [Clear description]
+**Frequency:** [X times across Y PRs/sessions]
+**Evidence:**
+- [PR/issue link or excerpt 1]
+- [PR/issue link or excerpt 2]
+
+### Analysis
+**Where it should be caught:** [Tooling/Docs/Invariant]
+**Impact if violated:** [Low/Medium/High]
+**Enforceable by automation:** [Yes/No]
+
+### Decision: [AUTOMATION | TIER 1 | TIER 2 | REFERENCE]
+
+**Rationale:** [1-2 sentences explaining why this tier/approach]
+
+### Proposed Change
+
+**Location:** [Exact file path + section heading]
+
+**Current state:** [What exists now, if anything]
+
+**Proposed addition:**
+```
+[Exact text to add - use positive constraints, not negative]
+```
+
+**Example in practice:**
+```
+[Show how this rule/check would prevent the failure]
+```
+
+### Implementation Steps
+1. [What to modify/add]
+2. [Testing/validation needed]
+3. [PR creation]
+
+### Next Action
+[Create PR? Add to automation? Update docs?]
+```
+
+### 6. Important constraints
+- Use positive language ("Do X" not "Don't do Y")
+- Be specific and measurable
+- Include examples showing correct behavior
+- If automation: specify exact tool/command
+- If Tier 1: must be universally applicable
+
+### 7. Get approval before implementing
+After proposing the change:
+- Ask if the user agrees with the tier/approach
+- Confirm the proposed wording is clear
+- Get approval before creating PR or modifying files
+
+## Examples
+
+**Automation example:**
+```
+Decision: AUTOMATION
+Location: .github/workflows/pr-check.yml
+Proposed: Add validator for PR body formatting
+Rationale: Enforceable via regex, prevents recurring formatting issues
+```
+
+**Tier 1 example:**
+```
+Decision: TIER 1
+Location: AGENTS.md → Critical Invariants
+Proposed: "InventoryService is the single source of truth for item quantities"
+Rationale: Project-wide invariant, violations cause data corruption
+```
+
+**Tier 2 example:**
+```
+Decision: TIER 2
+Location: docs/UI_PATTERNS.md
+Proposed: "Prefer IconButton over TextButton for toolbars (consistency)"
+Rationale: UI pattern, not critical but improves UX consistency
+```
+
+## Important Notes
+- Do NOT modify files until user approves
+- Prefer automation when possible (enforced > documented)
+- Keep constraints actionable and testable
+- Link to evidence (PRs/issues where pattern occurred)
+- This is about preventing future failures, not blame

--- a/skills/handoff/SKILL.md
+++ b/skills/handoff/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: handoff
+description: Generate a session handoff note for AIDE-based repos. Outputs a PR/issue-comment-ready handoff for context resets.
+---
+
+# AIDE Handoff
+
+Generate a session handoff note for context resets or multi-day work.
+
+## Workflow
+
+### 1. Locate repo root
+Walk up from current directory until you find `AGENTS.md`.
+
+### 2. Load handoff template (optional)
+Check if `.aide/docs/core/SESSION_HANDOFF.template.md` exists in repo.
+- If yes: Use its structure as a guide
+- If no: Use the built-in structure below
+
+### 3. Collect current state
+Gather this information:
+- Current branch: `git branch --show-current`
+- Current PR number (if exists): `gh pr status` or ask user
+- Related issue number (if exists): ask user or extract from PR
+- Current workflow stage (0-10 from IMPLEMENTATION_START, or other role)
+- Git status: `git status --short`
+- Recent commits: `git log --oneline -5`
+
+### 4. Ask for work context
+Prompt user for:
+- **Completed:** What tasks/steps have been finished?
+- **In Progress:** What's currently mid-flight?
+- **Blockers:** What's preventing progress?
+- **Next Actions:** What should happen next? (ordered list)
+- **Validation Status:** Are tests passing? Any known issues?
+
+### 5. Output handoff note (<=25 lines)
+```markdown
+# Session Handoff: [Task Name]
+
+**Date:** [current date]
+**Branch:** [branch-name]
+**PR:** #[number] (or "not created yet")
+**Issue:** #[number] (or "none")
+**Stage:** [current workflow stage]
+
+## Context
+[1-2 sentence summary of what this task is about]
+
+## Completed
+- [List with file references, e.g., "Updated InventoryService.cs:42-67"]
+- [Use specific line numbers when possible]
+
+## In Progress
+- [Current work items with specific TODOs]
+- [What's mid-flight but not finished]
+
+## Blockers
+- [What's preventing progress, if any]
+- [Technical blockers, design decisions needed, etc.]
+
+## Next Actions
+1. [First thing to do when resuming]
+2. [Second thing]
+3. [Third thing]
+
+## Validation Status
+- Tests: [passing/failing - list failing tests if any]
+- Lint: [passing/failing]
+- Build: [passing/failing]
+- Known issues: [any warnings or concerns]
+
+## File References
+[List key files touched with line ranges]
+```
+
+### 6. Where to post
+Ask user where to post this:
+- **PR comment (preferred):** `gh pr comment [pr-number] --body "[handoff]"`
+- **Issue comment:** `gh issue comment [issue-number] --body "[handoff]"`
+- **Print only:** Just display for user to copy
+
+**Do NOT commit handoff files to the repository unless explicitly requested.**
+
+## Important Notes
+- Be specific with file paths and line numbers
+- Include commit SHAs for key changes
+- Keep it concise but complete
+- Focus on "what needs to happen next" not "what I did today"
+- This is for resumption, not a status report

--- a/skills/install-claude.ps1
+++ b/skills/install-claude.ps1
@@ -1,0 +1,80 @@
+#!/usr/bin/env pwsh
+# Install AIDE skills for Claude Code (VS Code Extension or CLI)
+
+param(
+    [switch]$Symlink = $false,
+    [string]$SkillsPath = "$HOME\.claude\skills"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Installing AIDE skills for Claude Code..." -ForegroundColor Cyan
+
+# Get AIDE skills directory (script is in .aide/skills/)
+$aideSkillsDir = $PSScriptRoot
+if (-not (Test-Path $aideSkillsDir)) {
+    Write-Error "AIDE skills directory not found: $aideSkillsDir"
+    exit 1
+}
+
+# Ensure target directory exists
+if (-not (Test-Path $SkillsPath)) {
+    Write-Host "Creating skills directory: $SkillsPath" -ForegroundColor Yellow
+    New-Item -ItemType Directory -Force -Path $SkillsPath | Out-Null
+}
+
+# Get all skill directories (exclude README.md, scripts, etc.)
+$skills = Get-ChildItem -Path $aideSkillsDir -Directory | Where-Object {
+    Test-Path (Join-Path $_.FullName "SKILL.md")
+}
+
+if ($skills.Count -eq 0) {
+    Write-Warning "No skills found in $aideSkillsDir"
+    exit 0
+}
+
+Write-Host "Found $($skills.Count) skills to install" -ForegroundColor Green
+
+foreach ($skill in $skills) {
+    $skillName = $skill.Name
+    $sourcePath = $skill.FullName
+    $targetPath = Join-Path $SkillsPath $skillName
+
+    if ($Symlink) {
+        # Create symlink (requires admin on Windows)
+        if (Test-Path $targetPath) {
+            Write-Host "  Removing existing: $skillName" -ForegroundColor Yellow
+            Remove-Item -Recurse -Force $targetPath
+        }
+
+        Write-Host "  Symlinking: $skillName" -ForegroundColor Cyan
+        New-Item -ItemType SymbolicLink -Path $targetPath -Target $sourcePath | Out-Null
+    } else {
+        # Copy files
+        if (Test-Path $targetPath) {
+            Write-Host "  Updating: $skillName" -ForegroundColor Yellow
+            Remove-Item -Recurse -Force $targetPath
+        } else {
+            Write-Host "  Installing: $skillName" -ForegroundColor Green
+        }
+
+        Copy-Item -Recurse -Force $sourcePath $targetPath
+    }
+}
+
+Write-Host ""
+Write-Host "✅ Installation complete!" -ForegroundColor Green
+Write-Host ""
+Write-Host "Installed skills:" -ForegroundColor Cyan
+foreach ($skill in $skills) {
+    Write-Host "  /$($skill.Name)" -ForegroundColor White
+}
+Write-Host ""
+Write-Host "Next steps:" -ForegroundColor Yellow
+Write-Host "  1. Reload VS Code (Ctrl+Shift+P → 'Reload Window')"
+Write-Host "  2. Type '/' in Claude Code chat to see available commands"
+Write-Host ""
+
+if (-not $Symlink) {
+    Write-Host "Note: Skills were copied. To auto-sync with AIDE updates, re-run with -Symlink" -ForegroundColor Gray
+}

--- a/skills/package-codex.ps1
+++ b/skills/package-codex.ps1
@@ -1,0 +1,83 @@
+#!/usr/bin/env pwsh
+# Package AIDE skills for Codex (creates .skill zip files)
+
+param(
+    [string]$OutputDir = "$PSScriptRoot\dist"
+)
+
+$ErrorActionPreference = "Stop"
+
+Write-Host "Packaging AIDE skills for Codex..." -ForegroundColor Cyan
+
+# Get AIDE skills directory
+$aideSkillsDir = $PSScriptRoot
+if (-not (Test-Path $aideSkillsDir)) {
+    Write-Error "AIDE skills directory not found: $aideSkillsDir"
+    exit 1
+}
+
+# Ensure output directory exists
+if (-not (Test-Path $OutputDir)) {
+    Write-Host "Creating output directory: $OutputDir" -ForegroundColor Yellow
+    New-Item -ItemType Directory -Force -Path $OutputDir | Out-Null
+}
+
+# Get all skill directories
+$skills = Get-ChildItem -Path $aideSkillsDir -Directory | Where-Object {
+    Test-Path (Join-Path $_.FullName "SKILL.md")
+}
+
+if ($skills.Count -eq 0) {
+    Write-Warning "No skills found in $aideSkillsDir"
+    exit 0
+}
+
+Write-Host "Found $($skills.Count) skills to package" -ForegroundColor Green
+
+# Load compression assembly
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+foreach ($skill in $skills) {
+    $skillName = $skill.Name
+    $sourcePath = $skill.FullName
+    $outputFile = Join-Path $OutputDir "aide-$skillName.skill"
+
+    Write-Host "  Packaging: aide-$skillName.skill" -ForegroundColor Cyan
+
+    # Remove existing package
+    if (Test-Path $outputFile) {
+        Remove-Item -Force $outputFile
+    }
+
+    # Create zip archive
+    [System.IO.Compression.ZipFile]::CreateFromDirectory(
+        $sourcePath,
+        $outputFile,
+        [System.IO.Compression.CompressionLevel]::Optimal,
+        $false
+    )
+
+    # Verify package was created
+    if (Test-Path $outputFile) {
+        $size = (Get-Item $outputFile).Length
+        $sizeKB = [math]::Round($size / 1KB, 2)
+        Write-Host "    ✓ Created: $sizeKB KB" -ForegroundColor Green
+    } else {
+        Write-Error "Failed to create package: $outputFile"
+    }
+}
+
+Write-Host ""
+Write-Host "✅ Packaging complete!" -ForegroundColor Green
+Write-Host ""
+Write-Host "Packaged skills:" -ForegroundColor Cyan
+Get-ChildItem -Path $OutputDir -Filter "*.skill" | ForEach-Object {
+    $sizeKB = [math]::Round($_.Length / 1KB, 2)
+    Write-Host "  $($_.Name) ($sizeKB KB)" -ForegroundColor White
+}
+Write-Host ""
+Write-Host "Next steps:" -ForegroundColor Yellow
+Write-Host "  1. Import .skill files via Codex extension UI ('Import Skill')"
+Write-Host "  2. Or attach to GitHub Release for distribution"
+Write-Host ""
+Write-Host "Output directory: $OutputDir" -ForegroundColor Gray

--- a/skills/plan/SKILL.md
+++ b/skills/plan/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: plan
+description: Create a two-layer AIDE implementation plan from an issue/PR spec. Reads AGENTS.md for constraints and outputs a plan plus a draft PR checklist.
+---
+
+# AIDE Plan
+
+Create a two-layer AIDE implementation plan from a task spec.
+
+## Workflow
+
+### 1. Locate repo root
+Walk up from current directory until you find `AGENTS.md`.
+
+### 2. Get the task spec
+Ask user for:
+- Issue/PR description text (preferred)
+- OR issue number (will fetch via `gh issue view [number]`)
+- OR PR number (will fetch via `gh pr view [number]`)
+
+If user provides a number, fetch the full spec with `gh`.
+
+### 3. Read project constraints
+Read `AGENTS.md` to capture:
+- Critical invariants (top section)
+- Design pillars
+- Architectural constraints
+- Quality commands (`{{RUN_ALL_TESTS_COMMAND}}`, `{{LINT_COMMAND}}`, etc.)
+- Testing policy
+
+### 4. Produce Layer 1 Constraints
+Extract project-wide rules that apply to this task:
+- Which invariants apply?
+- Which systems/services are authoritative?
+- What boundaries must be respected?
+- What patterns must be followed?
+
+Output as short bullet list (<=8 items).
+
+### 5. Produce Layer 2 Plan
+Create ordered implementation steps with exit criteria:
+
+Format:
+```
+1. [Step name] - [What to do] → Exit: [How to verify this step is done]
+2. [Step name] - [What to do] → Exit: [How to verify this step is done]
+...
+```
+
+Include:
+- Files likely to be touched
+- Testing strategy (smallest scope first)
+- Validation commands to run
+- Risks or unknowns
+
+Keep plan concise (<=12 steps).
+
+### 6. Output format
+```markdown
+## Layer 1: Constraints
+- [Project-wide rule that applies]
+- [Architectural boundary to respect]
+- [Authoritative service pattern]
+...
+
+## Layer 2: Implementation Plan
+
+**Files Likely Touched:**
+- [file path] - [why]
+- [file path] - [why]
+
+**Steps:**
+1. [Step] → Exit: [criteria]
+2. [Step] → Exit: [criteria]
+...
+
+**Testing Strategy:**
+- Unit tests: [which tests to write/modify]
+- Integration tests: [if needed]
+- Validation: `[command from AGENTS.md]`
+
+**Risks/Unknowns:**
+- [Any uncertainty or decision points]
+- [Questions to resolve before starting]
+
+## Draft PR Body
+```markdown
+Fixes #[issue-number]
+
+**Layer 1 Constraints:**
+- [List key constraints]
+
+**Implementation:**
+- [ ] [Step 1]
+- [ ] [Step 2]
+...
+
+**Validation:**
+- [ ] Lint passes: `[command]`
+- [ ] Tests pass: `[command]`
+- [ ] Smoke tests pass (if applicable): `[command]`
+
+**Testing:**
+[Description of test strategy]
+```
+```
+
+### 7. Get user approval
+After presenting the plan, ask:
+- Does this plan look correct?
+- Any missing steps or concerns?
+- Ready to proceed with implementation?
+
+**Do NOT start implementing until user approves the plan.**
+
+## Important Notes
+- Planning only - no code changes yet
+- Be specific about exit criteria (measurable, verifiable)
+- Prefer narrow test scope first, then broaden
+- Call out any unknowns or decision points upfront
+- The plan should be reviewable and adjustable before coding starts

--- a/skills/prime/SKILL.md
+++ b/skills/prime/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: prime
+description: Minimal project priming for AIDE-based repos. Loads AGENT_ORIENTATION.md and AGENTS.md (Tier 1) and returns a short prime summary plus the next input needed.
+---
+
+# AIDE Prime
+
+Minimal project priming for AIDE-based repos. Use when starting a fresh session.
+
+## Workflow
+
+### 1. Locate repo root
+Walk up from the current working directory until you find `AGENTS.md`. This is the repo root.
+
+### 2. Read Tier 1 entry docs
+- If `AGENT_ORIENTATION.md` exists at repo root, read it
+- Always read `AGENTS.md` if present
+- Do not read any other files yet
+
+### 3. Extract Quick Constraints
+Look for a `## Quick Constraints` section in `AGENTS.md`:
+- If found: extract all bullet points under that section
+- If not found: use generic message "project-defined (see AGENTS.md)"
+
+### 4. Output Prime Report (concise, <=10 lines)
+
+Format:
+```
+Primed: AGENT_ORIENTATION.md: [yes/no] AGENTS.md: [yes/no]
+Constraints: [semicolon-separated list or "project-defined (see AGENTS.md)"]
+Next input needed: task spec or PR/issue link
+If resuming work: provide handoff or PR link
+```
+
+### 5. Next Steps
+After priming, ask the user:
+- What task they want to work on (issue/PR/spec)
+- OR if they need to choose a role workflow
+
+## Important Notes
+- Do NOT choose or assume a role
+- Do NOT load role primers yet
+- Do NOT run git commands or modify files
+- Keep output concise and deterministic
+- This is orientation only - the actual work happens after role selection

--- a/skills/quality/SKILL.md
+++ b/skills/quality/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: quality
+description: Run project quality gates from AGENTS.md placeholder mappings. Executes lint and tests based on project configuration.
+---
+
+# AIDE Quality
+
+Run project quality gates from AGENTS.md placeholder mappings.
+
+## Workflow
+
+### 1. Locate repo root
+Walk up from current directory until you find `AGENTS.md`.
+
+### 2. Load quality commands
+Read `AGENTS.md` and extract these placeholder mappings:
+- `{{RUN_ALL_TESTS_COMMAND}}` - Full test suite
+- `{{RUN_UNIT_TESTS_COMMAND}}` - Unit tests only (optional)
+- `{{LINT_COMMAND}}` - Linting
+- `{{FORMAT_COMMAND}}` - Formatting (optional)
+- `{{SMOKE_TEST_COMMAND}}` - Smoke tests (optional)
+
+### 3. Determine scope
+Ask the user what scope they want:
+- **Default (recommended):** Lint + unit tests (fast feedback)
+- **Full:** All tests + smoke tests
+- **Dry-run:** Print commands without executing
+
+### 4. Execute validation
+Run the selected commands in this order:
+1. Lint (if defined)
+2. Unit tests OR all tests (depending on scope)
+3. Smoke tests (if full scope and defined)
+
+### 5. Output format (<=15 lines)
+```
+## Quality Gate Results
+
+Repo: [repo root path]
+Scope: [default/full/dry-run]
+
+Commands:
+- Lint: [command or "not defined"]
+- Tests: [command or "not defined"]
+- Smoke: [command or "not defined"]
+
+Results:
+✅/❌ Lint: [passed/failed/skipped]
+✅/❌ Tests: [X passed, Y failed/skipped]
+✅/❌ Smoke: [passed/failed/skipped]
+
+[If failures: show failing test names and logs]
+
+Next: [Fix failures OR proceed with PR if all passed]
+```
+
+## Important Notes
+- Never modify test files
+- If commands are missing from AGENTS.md, ask user to provide them
+- Stop immediately if lint or tests fail - do not proceed
+- For CI/PR workflows, always run at least lint + tests before marking ready

--- a/tools/codex-skills/README.md
+++ b/tools/codex-skills/README.md
@@ -1,5 +1,11 @@
 # Codex skills (AIDE)
 
+> **⚠️ DEPRECATED:** This directory is being phased out in favor of the unified skills system at `../../skills/`.
+>
+> **New location:** [../../skills/README.md](../../skills/README.md)
+>
+> This directory remains for backward compatibility but will be removed in a future release.
+
 This folder contains the source for AIDE's `aide-*` Codex skills.
 
 ## Folder layout
@@ -27,7 +33,13 @@ Skills include optional `scripts/` for deterministic execution in environments t
 
 ## Build packages locally
 
-From the AIDE repo root:
+**Recommended (new unified system):**
+
+```powershell
+powershell -ExecutionPolicy Bypass -File skills/package-codex.ps1
+```
+
+**Legacy (this directory):**
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File tools/codex-skills/scripts/package_all.ps1


### PR DESCRIPTION
Migrates AIDE skills to a unified, agent-agnostic distribution system at `skills/`.

## Summary

Creates a single source of truth for AIDE skills that works across all AI coding tools (Claude Code, Codex, Cursor, Windsurf, etc.) instead of maintaining separate implementations.

## Changes

### New Unified Skills System (`skills/`)

- **5 Core Skills:** `prime`, `quality`, `handoff`, `plan`, `evolve`
- **Installation Scripts:**
  - `install-claude.ps1` - Install for Claude Code (VS Code Extension & CLI)
  - `package-codex.ps1` - Package as `.skill` zips for Codex
- **Documentation:**
  - `README.md` - Installation guide for all tools
  - `MIGRATION.md` - Transition plan from old structure

### Updated Infrastructure

- **CI Workflow:** Updated `.github/workflows/codex-skills.yml` to use `skills/package-codex.ps1`
- **Old Location:** Deprecated `tools/codex-skills/` with migration notice

### Skill Format

All skills use consistent YAML frontmatter + markdown format:

```markdown
---
name: skill-name
description: Brief description
---

# Skill Title

Instructions for the AI agent...
```

This format works across Claude Code, Codex, Cursor, Windsurf, and other tools.

## Benefits

1. **Agent-Agnostic** - One skill definition, multiple tools
2. **Simplified Maintenance** - Update once, distribute to all tools
3. **Easy Distribution** - Scripts handle tool-specific packaging
4. **Version Controlled** - Skills in repo, not user config

## Installation

### For Claude Code Users

```bash
.aide/skills/install-claude.ps1
```

### For Codex Users

```bash
.aide/skills/package-codex.ps1
# Import generated .skill files via Codex UI
```

### For AIDE Framework

```bash
git clone https://github.com/LightForgeLabsStudio/AIDE .aide
cd .aide/skills
./install-claude.ps1
```

## Migration Plan

**Phase 1 (This PR):** Unified system is primary, old location deprecated but functional
**Phase 2 (Future):** Remove `tools/codex-skills/src/` after transition period

## Backward Compatibility

- CI still packages from new location
- Codex users see no change (same `.skill` format)
- Old `tools/codex-skills/` marked deprecated with migration instructions

## Testing

- ✅ Claude Code: Skills install and appear in `/` menu
- ✅ Codex: Package script generates valid `.skill` files
- ✅ CI: Workflow packages and uploads to releases
- ✅ Docs: Clear installation instructions for each tool

## Related

- Builds on PR#17 (Add Codex skill sources + release packaging)
- Addresses feedback about tool-specific coupling
- Enables Cole Medin's PIV Loop workflow patterns

---

Generated with Claude Code