### PR TITLE
Tooling: migrate from type labels to Issue Types (refs LightbornExileDivinityEngine#374)

### DIFF
--- a/docs/agents/GITHUB_LABELS.md
+++ b/docs/agents/GITHUB_LABELS.md
@@ -8,7 +8,6 @@
 
 | Label | Color | Description | Usage |
 |-------|-------|-------------|-------|
-| `documentation` | #0075ca | Improvements or additions to documentation | Docs updates, guides |
 | `question` | #d876e3 | Further information is requested | Clarifications, discussions |
 | `duplicate` | #cfd3d7 | This issue or pull request already exists | Duplicate of existing issue |
 | `invalid` | #e4e669 | This doesn't seem right | Invalid/incorrect issues |
@@ -18,15 +17,15 @@
 
 | Label | Color | Description |
 |-------|-------|-------------|
-| `area: drone-ai` | #c5def5 | Drone behavior, pathfinding, state machine |
-| `area: job-system` | #c5def5 | Job assignment, priority, scheduling |
-| `area: buildings` | #c5def5 | Building system, construction, upgrades |
-| `area: resources` | #c5def5 | Resource management, harvesting, storage |
-| `area: ui` | #c5def5 | User interface, HUD, menus |
-| `area: combat` | #c5def5 | Combat mechanics, weapons, enemies |
-| `area: testing` | #c5def5 | Test infrastructure, test cases |
-| `area: tooling` | #c5def5 | Dev tools, build scripts, CI/CD |
-| `area: multiple-systems` | #1d76db | Cross-cutting changes across multiple systems |
+| `area:drone-ai` | #c5def5 | Drone behavior, pathfinding, state machine |
+| `area:job-system` | #c5def5 | Job assignment, priority, scheduling |
+| `area:buildings` | #c5def5 | Building system, construction, upgrades |
+| `area:resources` | #c5def5 | Resource management, harvesting, storage |
+| `area:ui` | #c5def5 | User interface, HUD, menus |
+| `area:combat` | #c5def5 | Combat mechanics, weapons, enemies |
+| `area:testing` | #c5def5 | Test infrastructure, test cases |
+| `area:tooling` | #c5def5 | Dev tools, build scripts, CI/CD |
+| `area:multiple-systems` | #1d76db | Cross-cutting changes across multiple systems |
 
 **Usage:** Every issue should have at least one `area:` label.
 
@@ -34,10 +33,10 @@
 
 | Label | Color | Description | Response Time |
 |-------|-------|-------------|---------------|
-| `priority: critical` | #b60205 | Blocks development | Immediate |
-| `priority: high` | #d93f0b | Should address soon | This sprint/week |
-| `priority: medium` | #fbca04 | Moderate importance | Next sprint |
-| `priority: low` | #0e8a16 | Nice to have | Backlog |
+| `priority:critical` | #b60205 | Blocks development | Immediate |
+| `priority:high` | #d93f0b | Should address soon | This sprint/week |
+| `priority:medium` | #fbca04 | Moderate importance | Next sprint |
+| `priority:low` | #0e8a16 | Nice to have | Backlog |
 
 **Usage:** Assign based on impact and urgency.
 
@@ -45,10 +44,10 @@
 
 | Label | Color | Description | Workflow State |
 |-------|-------|-------------|----------------|
-| `status: needs-spec` | #ededed | Needs specification | Pre-implementation |
-| `status: ready` | #0e8a16 | Ready for implementation | Step 0: Spec Intake |
-| `status: in-progress` | #fbca04 | Currently being worked on | Step 2-7: Implementation |
-| `status: needs-review` | #8B4513 | Awaiting code review | Step 7: PR Ready |
+| `status:needs-spec` | #ededed | Needs specification | Pre-implementation |
+| `status:ready` | #0e8a16 | Ready for implementation | Step 0: Spec Intake |
+| `status:in-progress` | #fbca04 | Currently being worked on | Step 2-7: Implementation |
+| `status:needs-review` | #8B4513 | Awaiting code review | Step 7: PR Ready |
 
 **Status Workflow:**
 ```
@@ -68,16 +67,19 @@ needs-spec -> ready -> in-progress -> needs-review -> (merged/closed)
 
 **Required:**
 - Issue Type is set via GitHub Issue Types (no type labels).
-- Area label: `area: <system>`
-- Priority label: `priority: <level>`
-- Status label: `status: needs-spec` or `status: ready`
+- Area label: `area:<system>`
+- Priority label: `priority:<level>`
+- Status label: `status:needs-spec` or `status:ready`
+
+**Deprecated (do not apply):**
+- Legacy type labels: `bug`, `enhancement`, `technical-debt`, `documentation`, `testing`, `chore`
 
 **Example:**
 ```bash
 gh issue create \
   --title "Drone crashes on empty queue" \
   --body "..." \
-  --label "area: drone-ai,priority: high,status: ready"
+  --label "area:drone-ai,priority:high,status:ready"
 ```
 
 ### During Implementation
@@ -86,17 +88,17 @@ gh issue create \
 
 ```bash
 # Starting work (Step 2)
-gh issue edit 42 --add-label "status: in-progress" --remove-label "status: ready"
+gh issue edit 42 --add-label "status:in-progress" --remove-label "status:ready"
 
 # PR ready for review (Step 6)
-gh issue edit 42 --add-label "status: needs-review" --remove-label "status: in-progress"
+gh issue edit 42 --add-label "status:needs-review" --remove-label "status:in-progress"
 
 ```
 
 ### On PR Creation
 
 **PRs inherit labels from linked issue** (via `Fixes #42`), but can also have:
-- Review status: `status: needs-review`
+- Review status: `status:needs-review`
 - Area labels: Same as linked issue
 
 ## Querying by Labels
@@ -105,24 +107,24 @@ gh issue edit 42 --add-label "status: needs-review" --remove-label "status: in-p
 
 ```bash
 # Ready for implementation
-gh issue list --label "status: ready" --state open
+gh issue list --label "status:ready" --state open
 
 # High priority work
-gh issue list --label "priority: high" --state open
+gh issue list --label "priority:high" --state open
 
 # My area of work
-gh issue list --label "area: drone-ai" --state open
+gh issue list --label "area:drone-ai" --state open
 ```
 
 ### Check current work
 
 ```bash
 # What's in progress?
-gh issue list --label "status: in-progress" --state open
+gh issue list --label "status:in-progress" --state open
 
 
 # What needs review?
-gh issue list --label "status: needs-review" --state open
+gh issue list --label "status:needs-review" --state open
 ```
 
 ### Filter by Epic
@@ -150,7 +152,7 @@ gh api graphql -f query='
 
 **Potential automations:**
 - Auto-apply `area:` based on files changed
-- Auto-apply `status: needs-review` when PR marked ready
+- Auto-apply `status:needs-review` when PR marked ready
 
 *Note: Not currently implemented, but available via GitHub Actions.*
 
@@ -160,12 +162,12 @@ gh api graphql -f query='
 
 ```bash
 # Create new area label
-gh label create "area: new-system" \
+gh label create "area:new-system" \
   --description "New system description" \
   --color "c5def5"
 
 # Create new priority/status label
-gh label create "priority: urgent" \
+gh label create "priority:urgent" \
   --description "Drop everything" \
   --color "ff0000"
 ```
@@ -177,7 +179,7 @@ gh label create "priority: urgent" \
 gh label edit "old-name" --name "new-name"
 
 # Update description/color
-gh label edit "priority: high" --description "Updated description" --color "ff0000"
+gh label edit "priority:high" --description "Updated description" --color "ff0000"
 ```
 
 ### Deleting Labels

--- a/tools/codex-skills/src/aide-issue/SKILL.md
+++ b/tools/codex-skills/src/aide-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aide-issue
-description: Create a GitHub issue following AIDE label conventions. Use when the user types /issue or asks to file an out-of-scope bug, feature, or tech debt. Creates the issue via gh with required labels (type, priority, area, status).
+description: Create a GitHub issue following AIDE label conventions. Applies priority/area/status labels and sets GitHub Issue Type (no type labels).
 ---
 
 # AIDE Issue
@@ -14,7 +14,7 @@ Create issues consistently with required labels so work is trackable and automat
 ### Inputs
 - Title (required)
 - Body (required; include reproduction/acceptance criteria)
-- Type: `feature` | `bug` | `technical-debt` | `chore` | `documentation` | `research` | `epic`
+- Issue Type (GitHub Issue Types): `feature` | `bug` | `technical-debt` | `chore` | `documentation` | `research` | `epic`
 - Priority: `critical` | `high` | `medium` | `low`
 - Area: `area:<name>` (string)
 - Status: `status:needs-spec` | `status:ready` | `status:in-progress`
@@ -23,7 +23,7 @@ Create issues consistently with required labels so work is trackable and automat
 ### Actions
 1) Build labels list: `priority:<x>, area:<y>, status:<z>` (+ `Epic` if epic)
 2) Run `gh issue create` with title/body/labels.
-3) Set GitHub Issue Type via `.aide/tools/set-issue-type.py --issue <num> --type <type>`.
+3) Set GitHub Issue Type via `.aide/tools/set-issue-type.py --issue <num> --type <type>`; fail if this step fails.
 4) Output the created issue URL.
 
 ## Notes

--- a/tools/codex-skills/src/aide-issue/references/README.md
+++ b/tools/codex-skills/src/aide-issue/references/README.md
@@ -2,10 +2,10 @@
 
 Creates issues via `gh issue create` using standard label fields:
 
-- Type: `feature` | `bug` | `technical-debt` | `chore` | `documentation` | `research` | `epic`
+- Issue Type is set via GitHub Issue Types (not labels): `feature` | `bug` | `technical-debt` | `chore` | `documentation` | `research` | `epic`
 - Priority: `priority:critical|high|medium|low`
 - Area: `area:<name>`
-- Status: `status:needs-spec|ready|in-progress`
+- Status: `status:needs-spec|status:ready|status:in-progress`
 
 If the target repo uses different label naming, adjust before using.
 

--- a/tools/codex-skills/src/aide-issue/scripts/issue.ps1
+++ b/tools/codex-skills/src/aide-issue/scripts/issue.ps1
@@ -33,4 +33,8 @@ if ($LASTEXITCODE -ne 0) {
 Write-Output $url
 $issueNumber = ($url -split "/")[-1]
 python .aide/tools/set-issue-type.py --issue $issueNumber --type $Type
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to set GitHub Issue Type for issue #$issueNumber. See previous output for details."
+    exit 1
+}
 

--- a/tools/issue-creator/issue-creator.py
+++ b/tools/issue-creator/issue-creator.py
@@ -176,7 +176,7 @@ class IssueCreator:
         """Query org issue types and return name->ID mapping"""
         query = f'''{{
           organization(login: "{self.repo_info['owner']}") {{
-            issueTypes(first: 25) {{
+            issueTypes(first: 100) {{
               nodes {{
                 id
                 name
@@ -852,7 +852,12 @@ Update mode metadata:
     parser.add_argument('--update-epic', type=int, metavar='NUM', help='Update Epic NUM and all children (matches by order)')
     parser.add_argument('--update-auto', action='store_true', help='Update issues based on issue_number metadata in specs')
     parser.add_argument('--add-child', type=int, metavar='EPIC_NUM', help='Create new issue from spec and link to Epic EPIC_NUM')
-    parser.add_argument('--sync-types', type=str, metavar='NUMS', help='Sync GitHub issue types from labels for comma-separated issue numbers (e.g. 42,43,44)')
+    parser.add_argument(
+        '--sync-types',
+        type=str,
+        metavar='NUMS',
+        help='Migration helper: sync GitHub Issue Types from legacy type labels for comma-separated issue numbers (e.g. 42,43,44)',
+    )
     parser.add_argument('--update-blockers', action='store_true', help='Update blocked_by relationships for issues described in the spec')
     parser.add_argument('--link-blocker', action='append', metavar='BLOCKED:BLOCKER', help='Explicitly link two existing issues via blocking (can be repeated)')
     parser.add_argument('--link-child', action='append', metavar='PARENT:CHILD', help='Explicitly link an existing child to an Epic (can be repeated)')

--- a/tools/migrate-type-labels.py
+++ b/tools/migrate-type-labels.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""
+Migrate away from legacy label-based issue "type" labels by:
+1) Setting GitHub Issue Type (if missing) based on legacy type labels
+2) Removing legacy type labels from issues
+
+This tool is intentionally explicit: it defaults to dry-run and requires --apply.
+
+Usage:
+  python .aide/tools/migrate-type-labels.py --state all
+  python .aide/tools/migrate-type-labels.py --state all --apply
+  python .aide/tools/migrate-type-labels.py --repo OWNER/REPO --state open --apply --limit 200
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+
+DEFAULT_ISSUE_TYPE_MAPPING = {
+    # Issue Type keys (normalized) -> GitHub Issue Type display name
+    "epic": "Epic",
+    "feature": "Feature",
+    "bug": "Bug",
+    "technical-debt": "Technical Debt",
+    "chore": "Chore",
+    "documentation": "Documentation",
+    "research": "Research",
+}
+
+# Legacy labels that represented issue type (deprecated).
+LEGACY_TYPE_LABEL_TO_ISSUE_TYPE_KEY = {
+    "bug": "bug",
+    "enhancement": "feature",
+    "technical-debt": "technical-debt",
+    "documentation": "documentation",
+    "testing": "chore",
+    "chore": "chore",
+}
+
+
+@dataclass(frozen=True)
+class Issue:
+    number: int
+    issue_id: str
+    issue_type_name: Optional[str]
+    labels: Dict[str, str]  # name -> id
+
+
+def _run_gh(args: List[str]) -> str:
+    p = subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+    if p.returncode != 0:
+        stderr = (p.stderr or "").strip()
+        stdout = (p.stdout or "").strip()
+        raise RuntimeError(f"gh {' '.join(args)} failed ({p.returncode}).\n{stderr}\n{stdout}".strip())
+    return p.stdout
+
+
+def _get_repo_owner_and_name(repo_override: Optional[str]) -> Tuple[str, str]:
+    if repo_override:
+        owner, name = repo_override.split("/", 1)
+        return owner, name
+    out = _run_gh(["repo", "view", "--json", "owner,name"])
+    data = json.loads(out)
+    return data["owner"]["login"], data["name"]
+
+
+def _get_issue_types(owner: str) -> Dict[str, str]:
+    query = f"""
+query {{
+  organization(login: "{owner}") {{
+    issueTypes(first: 100) {{
+      nodes {{ id name }}
+    }}
+  }}
+}}
+""".strip()
+    out = _run_gh(["api", "graphql", "-f", f"query={query}"])
+    data = json.loads(out)
+    org = data.get("data", {}).get("organization")
+    if not org:
+        raise RuntimeError(
+            f"Failed to query organization issue types for owner '{owner}'. "
+            "Ensure the repo owner is an organization and Issue Types are enabled."
+        )
+    nodes = org["issueTypes"]["nodes"]
+    return {n["name"]: n["id"] for n in nodes}
+
+
+def _iter_issues(owner: str, repo: str, state: str) -> Iterable[Issue]:
+    states = {"open": ["OPEN"], "closed": ["CLOSED"], "all": ["OPEN", "CLOSED"]}[state]
+    cursor: Optional[str] = None
+
+    while True:
+        after = f', after: "{cursor}"' if cursor else ""
+        query = f"""
+query {{
+  repository(owner: "{owner}", name: "{repo}") {{
+    issues(first: 100{after}, states: [{", ".join(states)}], orderBy: {{field: CREATED_AT, direction: ASC}}) {{
+      nodes {{
+        number
+        id
+        issueType {{ name }}
+        labels(first: 100) {{ nodes {{ id name }} }}
+      }}
+      pageInfo {{ hasNextPage endCursor }}
+    }}
+  }}
+}}
+""".strip()
+        out = _run_gh(["api", "graphql", "-f", f"query={query}"])
+        data = json.loads(out)
+        conn = data["data"]["repository"]["issues"]
+
+        for n in conn["nodes"]:
+            labels = {ln["name"]: ln["id"] for ln in n["labels"]["nodes"]}
+            issue_type = n["issueType"]["name"] if n.get("issueType") else None
+            yield Issue(
+                number=int(n["number"]),
+                issue_id=n["id"],
+                issue_type_name=issue_type,
+                labels=labels,
+            )
+
+        page = conn["pageInfo"]
+        if not page["hasNextPage"]:
+            return
+        cursor = page["endCursor"]
+
+
+def _set_issue_type(issue_id: str, issue_type_id: str) -> None:
+    mutation = f"""
+mutation {{
+  updateIssueIssueType(input: {{
+    issueId: "{issue_id}",
+    issueTypeId: "{issue_type_id}"
+  }}) {{
+    issue {{ number issueType {{ name }} }}
+  }}
+}}
+""".strip()
+    _run_gh(["api", "graphql", "-f", f"query={mutation}"])
+
+
+def _remove_labels(issue_id: str, label_ids: List[str]) -> None:
+    if not label_ids:
+        return
+    label_list = ", ".join([f"\"{lid}\"" for lid in label_ids])
+    mutation = f"""
+mutation {{
+  removeLabelsFromLabelable(input: {{
+    labelableId: "{issue_id}",
+    labelIds: [{label_list}]
+  }}) {{
+    clientMutationId
+  }}
+}}
+""".strip()
+    _run_gh(["api", "graphql", "-f", f"query={mutation}"])
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo", help="owner/repo override (default: current repo)")
+    parser.add_argument("--state", choices=["open", "closed", "all"], default="all")
+    parser.add_argument("--limit", type=int, default=0, help="Max issues to process (0 = no limit)")
+    parser.add_argument("--apply", action="store_true", help="Apply changes (default: dry-run)")
+    args = parser.parse_args()
+
+    owner, repo = _get_repo_owner_and_name(args.repo)
+    issue_types = _get_issue_types(owner)
+
+    # Build mapping from Issue Type key -> ID, based on display names.
+    issue_type_key_to_id: Dict[str, str] = {}
+    for key, display_name in DEFAULT_ISSUE_TYPE_MAPPING.items():
+        if display_name in issue_types:
+            issue_type_key_to_id[key] = issue_types[display_name]
+
+    missing_types = [k for k, v in DEFAULT_ISSUE_TYPE_MAPPING.items() if v not in issue_types]
+    if missing_types:
+        print(
+            "[WARN] Missing configured Issue Types in org: "
+            + ", ".join([DEFAULT_ISSUE_TYPE_MAPPING[k] for k in missing_types]),
+            file=sys.stderr,
+        )
+
+    planned_set = 0
+    planned_remove = 0
+    skipped_multi = 0
+    processed = 0
+
+    for issue in _iter_issues(owner, repo, args.state):
+        processed += 1
+        if args.limit and processed > args.limit:
+            break
+
+        legacy_labels = [name for name in issue.labels.keys() if name in LEGACY_TYPE_LABEL_TO_ISSUE_TYPE_KEY]
+        if not legacy_labels:
+            continue
+
+        # Remove all legacy type labels regardless (post-migration policy).
+        remove_label_ids = [issue.labels[name] for name in legacy_labels]
+
+        # Set issue type only if missing.
+        desired_key: Optional[str] = None
+        if issue.issue_type_name is None:
+            if len(legacy_labels) != 1:
+                skipped_multi += 1
+                print(
+                    f"[SKIP] #{issue.number}: multiple legacy type labels present: {', '.join(legacy_labels)}",
+                    file=sys.stderr,
+                )
+            else:
+                desired_key = LEGACY_TYPE_LABEL_TO_ISSUE_TYPE_KEY[legacy_labels[0]]
+
+        do_set = desired_key is not None and desired_key in issue_type_key_to_id
+        do_remove = len(remove_label_ids) > 0
+
+        if do_set:
+            planned_set += 1
+        if do_remove:
+            planned_remove += 1
+
+        if not args.apply:
+            parts: List[str] = []
+            if do_set:
+                parts.append(f"set Issue Type -> {DEFAULT_ISSUE_TYPE_MAPPING[desired_key]}")
+            parts.append(f"remove labels -> {', '.join(legacy_labels)}")
+            print(f"[DRY-RUN] #{issue.number}: " + "; ".join(parts))
+            continue
+
+        if do_set:
+            _set_issue_type(issue.issue_id, issue_type_key_to_id[desired_key])
+            print(f"[OK] #{issue.number}: set Issue Type -> {DEFAULT_ISSUE_TYPE_MAPPING[desired_key]}")
+
+        _remove_labels(issue.issue_id, remove_label_ids)
+        print(f"[OK] #{issue.number}: removed labels -> {', '.join(legacy_labels)}")
+
+    if not args.apply:
+        print(
+            f"[DRY-RUN] Planned: set issue types={planned_set}, remove legacy labels={planned_remove}, "
+            f"skipped_multi_label={skipped_multi}",
+            file=sys.stderr,
+        )
+        print("[DRY-RUN] Re-run with --apply to execute.", file=sys.stderr)
+    else:
+        print(
+            f"[DONE] Updated issues: set issue types={planned_set}, removed legacy labels={planned_remove}, "
+            f"skipped_multi_label={skipped_multi}",
+            file=sys.stderr,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+


### PR DESCRIPTION
## Summary
- Stop treating legacy labels (bug/enhancement/technical-debt/etc.) as issue type.
- Ensure issue creation sets GitHub Issue Type and only applies priority/area/status labels.
- Add a migration helper to remove legacy type labels.

Refs LightbornExileDivinityEngine#374