### PR TITLE
Require green CI before PR ready

### DIFF
--- a/docs/agents/implementation/STEP_6_PR_READY.md
+++ b/docs/agents/implementation/STEP_6_PR_READY.md
@@ -13,11 +13,12 @@ Pre-flight checklist:
 - [ ] Smoke tests passing (`{{SMOKE_TEST_COMMAND}}`)
 - [ ] Linting passing (`{{LINT_COMMAND}}`)
 - [ ] All tests passing (`{{RUN_ALL_TESTS_COMMAND}}`)
+- [ ] CI checks green (wait for GitHub Actions to finish successfully)
 - [ ] Code refinement complete (Step 5)
 - [ ] PR description updated with final summary
 - [ ] Issue reference included (`Fixes #<number>`)
 
-Mark ready:
+Mark ready (only after CI is green):
 ```bash
 # Flip from draft to ready
 gh pr ready <number>
@@ -31,4 +32,5 @@ PR is now visible to reviewers and will auto-close the linked issue on merge.
 ## Exit Criteria
 - PR is marked ready (not draft).
 - A completion comment is posted with test status.
+- CI checks are green at time of ready.
 

--- a/docs/core/CONTRIBUTING.md
+++ b/docs/core/CONTRIBUTING.md
@@ -19,8 +19,9 @@ See [agents/IMPLEMENTATION_START.md](../agents/IMPLEMENTATION_START.md) (index) 
 3. **Implement:** Follow [agents/IMPLEMENTATION_START.md](../agents/IMPLEMENTATION_START.md) workflow
 4. **Test:** Run tests per [TESTING_POLICY.md](TESTING_POLICY.md)
 5. **Document:** Update docs per [DOCUMENTATION_POLICY.md](DOCUMENTATION_POLICY.md)
-6. **Review:** Open PR for review per [agents/PR_REVIEW_START.md](../agents/PR_REVIEW_START.md)
-7. **Merge:** Address feedback, then implementer merges when approved by reviewer
+6. **CI:** Wait for CI checks to pass before marking PR ready
+7. **Review:** Open PR for review per [agents/PR_REVIEW_START.md](../agents/PR_REVIEW_START.md)
+8. **Merge:** Address feedback, then implementer merges when approved by reviewer
 
 **Important Constraints:**
 - Do not modify existing tests without explicit approval and justification


### PR DESCRIPTION
## Summary
Require CI checks to be green before marking PRs ready for review.

## Testing
Not applicable (docs-only).