### PR TITLE
Add pr-draft skill and route implement Step 2 through it

### DIFF
--- a/docs/agents/implementation/STEP_2_PLAN_AND_DRAFT_PR.md
+++ b/docs/agents/implementation/STEP_2_PLAN_AND_DRAFT_PR.md
@@ -60,7 +60,13 @@ Present plan:
 Ready to proceed?
 ```
 
-After approval, create branch + draft PR:
+After approval, create branch + draft PR via `/pr-draft`:
+
+```text
+/pr-draft
+```
+
+If you must run manually, use a body file and local validation (avoid inline escaped `--body` strings):
 
 Note: the PR body example uses a bash heredoc. For other shells, use the equivalent (e.g., PowerShell here-string) or edit the PR body in your editor.
 
@@ -75,12 +81,11 @@ Implements: #<issue-number>
 
 Co-Authored-By: [Agent Name] <agent@{{PROJECT_DOMAIN}}>"
 
-# Push and create draft PR with plan as checklist
+# Push branch
 git push -u origin feature/<brief-name>
 
-gh pr create --draft \
-  --title "<Feature brief>" \
-  --body "$(cat <<'EOF'
+# Write PR body to a temp file (example)
+cat > /tmp/pr_body.md <<'EOF'
 ## Summary
 [1-2 sentences]
 
@@ -104,7 +109,14 @@ gh pr create --draft \
 ---
 [Agent Name] Implementation
 EOF
-)"
+
+# Validate body formatting locally before create/edit
+powershell -ExecutionPolicy Bypass -File tools/validate_pr_body.ps1 -Body "$(cat /tmp/pr_body.md)"
+
+# Create draft PR from body file
+gh pr create --draft \
+  --title "<Feature brief>" \
+  --body-file /tmp/pr_body.md
 ```
 
 Key points:

--- a/skills/README.md
+++ b/skills/README.md
@@ -141,6 +141,7 @@ Check tool documentation for skill installation. Most support the same `SKILL.md
 | **sync** | `/sync` | End-of-session git sync (pull, push, verify) |
 | **issue** | `/issue` | Create labeled GitHub issue |
 | **pr-ready** | `/pr-ready` | Validate and mark PR ready |
+| **pr-draft** | `/pr-draft` | Create draft PR with validated body template |
 | **skill-author** | `/skill-author` | Create or update skills (frontmatter, workflow, install) |
 
 ## Development

--- a/skills/implement/SKILL.md
+++ b/skills/implement/SKILL.md
@@ -48,7 +48,7 @@ Canonical workflow (also see: `.aide/docs/agents/IMPLEMENTATION_ONE_PAGER.md`).
 
 **Phases (compressed guidance):**
 - Intake + survey (Steps 0–1): confirm spec and map the change surface (no coding).
-- Plan + draft PR (Step 2): write two-layer plan, get approval, open draft PR.
+- Plan + draft PR (Step 2): write two-layer plan, get approval, open draft PR via `/pr-draft`.
 - Implement + verify (Steps 3–5): implement, verify success criteria, refine.
 - Ship (Steps 6–10): mark PR ready, report back, address feedback, merge, sync main.
 

--- a/skills/pr-draft/SKILL.md
+++ b/skills/pr-draft/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: pr-draft
+description: Create a draft PR with a validated body template and issue linkage for AIDE repos.
+---
+
+# PR Draft
+
+Create a draft PR using a consistent template and validate body formatting locally before opening.
+
+## Inputs (ask first)
+
+- Base branch (default `main`)
+- Head branch (current branch if omitted)
+- PR title
+- Issue number to link (`Fixes #<number>`)
+- Summary bullets (1-4)
+- Plan checklist items
+- Validation checklist items
+- Keep as draft or mark ready (default draft)
+
+## Workflow
+
+1) Confirm branch state
+   - Verify not on `main`.
+   - Verify there is at least one commit on the branch.
+   - Push branch if needed: `git push -u origin <branch>`.
+
+2) Build PR body from template
+   - Write a temporary markdown file with:
+   - `Fixes #<number>`
+   - `## Summary`
+   - `## Implementation Plan` with `- [ ]` checklist
+   - `## Validation` with `- [ ]` checklist
+   - Optional `## Notes`
+
+3) Validate PR body locally before creating PR
+   - Run: `powershell -ExecutionPolicy Bypass -File tools/validate_pr_body.ps1 -Body (Get-Content -Raw <tmpfile>)`
+   - If validation fails, fix template/body and re-run until green.
+
+4) Create draft PR using body file
+   - Run: `gh pr create --draft --base <base> --head <head> --title "<title>" --body-file <tmpfile>`
+   - Do not use inline escaped `--body` strings.
+
+5) Post-create verification
+   - Run: `gh pr view --json number,url,body`
+   - Re-run local validator against returned `body` text to confirm persisted formatting.
+
+6) Cleanup
+   - Delete the temporary body file.
+
+## Output
+
+- PR URL
+- Linked issue number
+- Validation result (pass/fail)
+
+## Notes
+
+- Prefer this skill from `/implement` Step 2 for all draft PR creation.
+- Keep body path references inside backticks to satisfy PR body check.


### PR DESCRIPTION
## Summary
- add new /pr-draft skill for deterministic draft PR creation with local PR-body validation
- update implement skill guidance to call /pr-draft in Step 2
- update implementation Step 2 doc to use body-file + local validator fallback
- add pr-draft to skills catalog README

## Why
PR body formatting failures recur when bodies are authored ad hoc. This standardizes and validates PR body generation before opening/editing PRs.

## Validation
- skill installed successfully via .aide/skills/install-codex.ps1 in consumer repo
- verified new skill appears in .codex/skills/pr-draft/SKILL.md and updated implement guidance synced
