### PR TITLE
ADR: documentation taxonomy — living specs, dated decisions, GitHub-issue plans

### DIFF
--- a/AGENT_ORIENTATION.md
+++ b/AGENT_ORIENTATION.md
@@ -39,6 +39,9 @@ Project-side documents satisfy AIDE contracts.
 | Code style rules | `{{CODING_GUIDELINES_DOC}}` |
 | Test requirements | `{{TESTING_POLICY_DOC}}` |
 | Workflow rules | `{{CONTRIBUTING_DOC}}` |
+| System truth + binding invariants | `docs/specs/<system>.md` living specs (see `docs/core/DOCUMENT_TAXONOMY.md`) |
+
+Documentation kernel: [docs/core/DOCUMENT_TAXONOMY.md](docs/core/DOCUMENT_TAXONOMY.md) (six homes, two flavors, creation rule) and [docs/core/DOCUMENTATION_PRINCIPLES.md](docs/core/DOCUMENTATION_PRINCIPLES.md). Projects instantiate policy files from templates — no stubs pointing into `.aide/`.
 
 ### Tier 2: Compact Reference (On-Demand)
 

--- a/README.md
+++ b/README.md
@@ -64,9 +64,10 @@ Browse `docs/examples/` for your stack:
 Copy relevant templates to your project:
 
 ```bash
-# Core process docs (usually symlink these)
-ln -s .aide/docs/core/DOCUMENTATION_POLICY.md docs/DOCUMENTATION_POLICY.md
-ln -s .aide/docs/core/CONTRIBUTING.md docs/CONTRIBUTING.md
+# Core process docs — COPY and customize, never symlink or stub-point into .aide/
+# (AIDE defines shapes; your project owns instances. See docs/core/DOCUMENT_TAXONOMY.md)
+cp .aide/docs/core/DOCUMENTATION_POLICY.md docs/DOCUMENTATION_POLICY.md
+cp .aide/docs/core/CONTRIBUTING.md docs/CONTRIBUTING.md
 
 # Tech-specific standards (copy and customize)
 cp .aide/docs/examples/nodejs-typescript/TESTING_POLICY.md docs/TESTING_POLICY.md

--- a/docs/core/CONTRIBUTING.md
+++ b/docs/core/CONTRIBUTING.md
@@ -1,4 +1,6 @@
-# Contributing / Working Agreement
+# Contributing / Working Agreement (Template)
+
+> **Template — instantiate, don't point.** Copy into your project as `docs/CONTRIBUTING.md` and replace placeholders. Do not ship a stub that defers to this file.
 
 Minimal, repeatable workflow to keep changes consistent and documented.
 
@@ -106,10 +108,10 @@ See [TESTING_POLICY.md](TESTING_POLICY.md) for complete testing requirements.
 See [DOCUMENTATION_POLICY.md](DOCUMENTATION_POLICY.md) for complete documentation standards.
 
 **Summary:**
-- Update relevant docs when behavior changes (README, {{DEVELOPMENT_DOC}}, design docs)
+- Update relevant docs when behavior changes (README, {{DEVELOPMENT_DOC}}, the system spec)
 - Avoid duplicating information across files; use references
-- Only create new spec files when explicitly requested
-- System invariants live in {{CONTRACTS_DIRECTORY}} (if used); avoid restating them elsewhere
+- System invariants live in the relevant `docs/specs/<system>.md` Invariants section; avoid restating them elsewhere. See [DOCUMENT_TAXONOMY.md](DOCUMENT_TAXONOMY.md)
+- When executed work changes a system's invariants, updating that spec is part of the work
 
 ## Code Standards
 
@@ -145,5 +147,5 @@ Replace these placeholders:
 - `{{LANGUAGE}}` -> `TypeScript`, `Python`, `Rust`, `GDScript`
 - `{{FRAMEWORK}}` -> `React`, `Django`, `Actix`, `Godot`
 - `{{DEVELOPMENT_DOC}}` -> `docs/DEVELOPMENT.md`, `docs/ARCHITECTURE.md`
-- `{{CONTRACTS_DIRECTORY}}` -> `docs/contracts/`
+- `{{DESIGN_DIRECTORY}}` -> `design/`, `docs/design/`
 - `{{PROJECT_DESIGN_DOCS}}` -> `docs/design/`, `docs/architecture/`

--- a/docs/core/DOCUMENTATION_POLICY.md
+++ b/docs/core/DOCUMENTATION_POLICY.md
@@ -1,99 +1,42 @@
-# Documentation Policy
+# Documentation Policy (Template)
 
-Keep docs lean, consistent, and authoritative.
+> **Template — instantiate, don't point.** Copy this into your project as `docs/DOCUMENTATION_POLICY.md`, replace placeholders, and delete sections that don't apply. Do **not** ship a stub that defers to this file: the `.aide/` pin is not your project's source of truth. Kernel references: [DOCUMENT_TAXONOMY.md](DOCUMENT_TAXONOMY.md), [DOCUMENTATION_PRINCIPLES.md](DOCUMENTATION_PRINCIPLES.md).
 
-## Sources of Truth
+## Taxonomy (six homes, two flavors)
 
-Define your project's documentation hierarchy:
+| Home | Question answered | Flavor |
+| --- | --- | --- |
+| `{{DESIGN_DIRECTORY}}` | Why does this product exist and feel this way? | Living |
+| `docs/specs/` | What is true of this system now, and what must remain true? | Living |
+| `docs/decisions/` | What did we choose that is hard to reverse, and why? | Dated |
+| GitHub epics/issues | How and when? | Executed and closed — these are the plans |
+| `docs/evaluations/` | What did we learn? | Dated |
+| Conventions ({{CODING_GUIDELINES_DOC}}, {{TESTING_POLICY_DOC}}, {{CONTRIBUTING_DOC}}) | How do we work? | Living |
 
-- **README.md**: User/player-facing basics (install, run, key features)
-- **GitHub Epics + child Issues**: Specs and implementation state
-- **{{PROJECT_SUMMARY_DOC}}**: High-level project overview and current state
-- **{{DEVELOPMENT_DOC}}**: Architecture and how to extend/debug
-- **{{CONTRIBUTING_DOC}}**: Workflow, specs, testing, review process
-- **{{CONTRACTS_DIRECTORY}}**: System invariants/contracts (project-level, optional)
+**Living** docs claim to be current and are the only maintenance burden — keep the set small. **Dated** records are append-only and never edited after the fact (status lines only).
 
-Customize this list to match your project's structure.
+## Creation Rule
+
+> System truth → spec. Hard-to-reverse choice → ADR. Execution → issue.
+
+- A **spec** (`docs/specs/<system>.md`) is the living description of a system, with status frontmatter and a binding **Invariants** section. Load it before modifying that system. When executed work changes invariants, updating the spec is part of the work.
+- An **ADR** (`docs/decisions/YYYY-MM-DD-slug.md`) is written only when real alternatives existed, the choice constrains future work, and a newcomer could accidentally reverse it.
+- **Plans are GitHub issues.** There is no plans folder. No contracts/reports/review/handoffs folders either — see the taxonomy doc for where that content lives.
 
 ## Update Rules
 
-- Update only the relevant sources; avoid duplicating the same details across multiple files
-- When behavior changes, touch the single best place (README for users, {{DEVELOPMENT_DOC}} for developers)
-- Do not remove or rewrite existing tests without explicit approval
-- Confirm with the requester before initiating large refactors or cross-cutting doc reorganizations
-- Align on intent and testing scope before commits/PRs (no surprise changes)
+- Update only the relevant source; never duplicate the same fact across files — link instead.
+- When behavior changes: README for users, {{DEVELOPMENT_DOC}} for developers, the system spec for invariants.
+- Implementation state is queried from GitHub (`{{IMPLEMENTATION_STATUS_QUERY}}`), never tracked in markdown snapshots.
+- Git commits serve as the changelog during active development; a formal `CHANGELOG.md` is optional until public release.
 
-## Changelog Policy
+## Allowed Exception: Token-Efficient Summaries
 
-During active development, git commits serve as the technical changelog. Commit messages should be descriptive and include what was tested.
+Condensed agent summaries (e.g. `DESIGN_QUICK_REFERENCE.md`) may duplicate content when they clearly state they are non-authoritative, link the source, and are kept synchronized.
 
-A formal `CHANGELOG.md` is optional and should be added when preparing for public releases or when the project reaches a stable milestone. If created, changelog entries should include:
-- Version number and date
-- Summary of changes (new features, fixes, breaking changes)
-- Tests run or manual verification performed
+## Placeholders
 
-## Adding/Editing Docs
-
-- Add a brief feature summary and implementation approach in GitHub issues/PRs before coding
-- Prefer links/references to existing sections instead of copy/pasting content
-- Note known gaps or future work where applicable
-
-## Allowed Exceptions to No-Duplication Policy
-
-In rare cases, duplication is permitted when there is a clear operational benefit that outweighs the maintenance cost:
-
-### Token Optimization for Agents
-
-**Exception:** Quick reference documents (e.g., `DESIGN_QUICK_REFERENCE.md`, `API_QUICK_REFERENCE.md`)
-
-- **Purpose:** Condensed summaries for agent token efficiency
-- **Justification:** Reading full docs (10,000+ tokens) vs quick reference (500 tokens) = 95%+ reduction
-- **Requirements:**
-  - Must clearly state it is NOT authoritative
-  - Must link to authoritative sources
-  - Must be kept synchronized when source docs change
-  - Must cover ALL relevant topics (not selective)
-
-**Agent Token Economy Best Practices:**
-
-All agent-facing docs should prioritize token efficiency to maximize context budget for code analysis and implementation. See `.aide/docs/agents/TOKEN_ECONOMY.md` for comprehensive strategies.
-
-- **Prefer concise directives over verbose explanations**
-- **Use bullet points and checklists instead of paragraphs**
-- **Reference authoritative docs instead of duplicating content**
-- **Front-load critical information (most important rules first)**
-- **Use quick reference documents when available**
-- **Avoid redundant examples (one clear example > three similar ones)**
-
-### ~~Implementation State Tracking~~ (DEPRECATED)
-
-**Former Exception:** `IMPLEMENTATION_STATUS.md` (deprecated as of AIDE v1.1)
-
-- **Replaced by:** GitHub Issues/PRs/Epics (query via `gh` CLI)
-- **Rationale:** Static markdown files fall out of sync. GitHub is the actual canonical state and auto-updates on PR merge.
-- **Migration:** Use GitHub CLI queries instead of reading stale markdown:
-  ```bash
-  gh issue list --label "status:in-progress" --state open  # Current work
-  gh pr list --state open                                   # Active PRs
-  gh issue list --label "status:ready" --state open        # Ready to implement
-  ```
-- **See:** [GITHUB_QUERIES.md](../agents/GITHUB_QUERIES.md) for comprehensive query reference
-
-**Recommendation:** Use GitHub as single source of truth for implementation state. Agents query current state dynamically rather than reading snapshot documents.
-
-**When to add new exceptions:**
-- Operational benefit must be significant and measurable
-- Exception must be explicitly documented here
-- Must include synchronization requirements
-- Prefer references over duplication whenever possible
-
-## Customization for Your Project
-
-Replace these placeholders with your actual documentation structure:
-
-- `{{PROJECT_SUMMARY_DOC}}` -> `docs/PROJECT_SUMMARY.md` or `docs/OVERVIEW.md`
-- `{{DEVELOPMENT_DOC}}` -> `docs/DEVELOPMENT.md` or `docs/ARCHITECTURE.md`
-- `{{CONTRIBUTING_DOC}}` -> `docs/CONTRIBUTING.md` or `CONTRIBUTING.md`
-- `{{CONTRACTS_DIRECTORY}}` -> `docs/contracts/`
-- `{{IMPLEMENTATION_STATUS_QUERY}}` -> `gh issue list --label "status:in-progress"` (see [GITHUB_QUERIES.md](../agents/GITHUB_QUERIES.md))
-- `{{PROJECT_DESIGN_DOCS}}` -> `docs/design/`, `docs/architecture/`
+- `{{DESIGN_DIRECTORY}}` → `design/`, `docs/design/`
+- `{{DEVELOPMENT_DOC}}` → `docs/DEVELOPMENT.md`, `docs/ARCHITECTURE.md`
+- `{{CODING_GUIDELINES_DOC}}` / `{{TESTING_POLICY_DOC}}` / `{{CONTRIBUTING_DOC}}` → your convention docs
+- `{{IMPLEMENTATION_STATUS_QUERY}}` → e.g. `gh issue list --label "status:in-progress"`

--- a/docs/core/DOCUMENTATION_PRINCIPLES.md
+++ b/docs/core/DOCUMENTATION_PRINCIPLES.md
@@ -1,0 +1,46 @@
+# Documentation Principles
+
+Authoritative design principles for AIDE documentation. Adapted from [Build-A-Better-Business/docs-template](https://github.com/Build-A-Better-Business/docs-template); pairs with [DOCUMENT_TAXONOMY.md](DOCUMENT_TAXONOMY.md).
+
+**Audience:** primarily AI coding agents, secondarily human contributors. Optimize for reliable agent execution while remaining easy for humans to read.
+
+## Core Principles (priority order)
+
+1. **Speed** — readers reach the canonical source in one or two hops. Put frequently needed content where the reader already is; move rare detail behind on-demand pointers.
+2. **Context efficiency** — load only what the task needs. One fact, one home; pointers everywhere else.
+3. **Token cost** — verbose reference material lives off the default reading path; pair it with token-efficient summaries when agents need it often.
+
+When principles conflict: speed for common workflows > context efficiency for edge cases > canonical-source discipline over convenience.
+
+## Document Patterns
+
+- **Pointer docs** — link hubs, no normative content (e.g. `START_HERE.md`). Change when navigation changes.
+- **Canonical docs** — single source of truth (specs, conventions). Duplicated nowhere, updated in one place.
+- **On-demand guides** — workflow narratives off the default path; may repeat small snippets for readability but defer to canonicals for rules.
+- **Token-efficient summaries** — condensed agent versions of verbose sources; must state they are non-authoritative, link the source, and stay synchronized.
+
+## Anti-Patterns
+
+- Duplicating facts across files
+- **Stub files that defer to the `.aide/` submodule for their substance** — projects instantiate real files from templates instead
+- Plan/status documents that duplicate the issue tracker
+- Transient work artifacts (session handoffs, PR findings files) filed as documentation
+- Living and dated content mixed in one folder — the living set must stay small and obvious
+- Restating general engineering knowledge as repo-specific convention
+- Orphaned docs with no path from a navigation doc
+
+## Decision Framework
+
+When adding documentation, ask:
+
+1. Is this system truth (→ spec), a hard-to-reverse choice (→ ADR), execution detail (→ issue), or learning (→ evaluation)?
+2. Is it already authoritative elsewhere? Link, don't copy.
+3. Does it claim to be current? Then it joins the living set — keep that set small.
+4. Would a competent agent already do this without being told? Then omit it.
+
+## Preventing Drift
+
+- One fact, one home; link instead of copy.
+- Dated records never get content edits after the fact (status lines only).
+- The closing step of work that changes invariants is updating the relevant living spec.
+- Update navigation docs when files move.

--- a/docs/core/DOCUMENT_TAXONOMY.md
+++ b/docs/core/DOCUMENT_TAXONOMY.md
@@ -1,0 +1,66 @@
+# Document Taxonomy
+
+Canonical AIDE documentation kernel. Defined by ADR [2026-06-10-documentation-taxonomy-living-specs.md](../decisions/2026-06-10-documentation-taxonomy-living-specs.md), adapted from [Build-A-Better-Business/docs-template](https://github.com/Build-A-Better-Business/docs-template).
+
+**AIDE defines shapes; projects own instances.** No project document may point into `.aide/` for its substance — projects instantiate real files from AIDE templates. The submodule pin must never be a project's source of truth.
+
+## Six Homes, Two Flavors
+
+The dividing line is **time**, not content. A document either *claims to be current* (living — the only maintenance burden) or *records a moment* (dated — append-only, cannot drift because it does not claim currency).
+
+| Home | Question answered | Flavor |
+| --- | --- | --- |
+| `design/` (or project equivalent) | Why does this product exist and feel this way? | **Living** |
+| `docs/specs/` | What is true of this system now, and what must remain true? | **Living** |
+| `docs/decisions/` | What did we choose that is hard to reverse, and why? | Dated |
+| GitHub epics/issues | How and when? | Executed and closed — these **are** the plans |
+| `docs/evaluations/` | What did we learn? | Dated |
+| Conventions (coding guidelines, testing policy, contributing) | How do we work? | **Living** |
+
+Plus `docs/archive/` for superseded material retained as historical context.
+
+## Creation Rule
+
+> **System truth → spec. Hard-to-reverse choice → ADR. Execution → issue.**
+
+ADR threshold: real alternatives existed, the choice constrains future work, and a newcomer could accidentally reverse it. Most features never need one.
+
+## Specs Are Living System Documents
+
+A spec is the canonical description of a **system** (not a feature increment): its model, its current shape, and an explicit **Invariants** section carrying binding "what must remain true" rules. Specs are updated as architecture matures — they are the load-before-you-touch layer for agents.
+
+Frontmatter schema:
+
+```yaml
+---
+title: <system name>
+description: <one line>
+status: draft | accepted | superseded
+created: YYYY-MM-DD
+last_updated: YYYY-MM-DD
+---
+```
+
+Closing step of any executed epic or accepted decision that establishes new invariants: **update the relevant living spec.** This is how living docs stay current without a separate audit habit.
+
+## Dated Records
+
+- **Decisions (ADRs)** — slim records: Context, Decision, Rationale, Consequences. Status values: `Accepted (durable decision — current)`, `Executed (historical record)`, `Superseded by <file>`. Never edited after the fact except to update status.
+- **Evaluations** — audits, reviews, research, retrospectives. Replaces `reports/` naming.
+
+## Explicitly Rejected Categories
+
+- **No `plans/` folder.** Execution detail lives in GitHub epics and issues. Plan documents duplicate the tracker and rot.
+- **No `contracts/` folder.** Invariants live inside the relevant spec's Invariants section — on the load path, not in a separate archive.
+- **No `reports/` / `review/` / `handoffs/` folders.** Evaluations are dated records in `docs/evaluations/`; PR reviews live on GitHub; session handoffs are transient (archive or delete).
+- **No implementation-status snapshots.** Query GitHub (`gh`) for live state.
+
+## Naming
+
+- Dated records: `YYYY-MM-DD-slug.md` (preferred over `NNNN-slug` — no renumbering churn).
+- Living specs: `slug.md`, named for the system, not the feature increment.
+
+## See Also
+
+- [DOCUMENTATION_PRINCIPLES.md](DOCUMENTATION_PRINCIPLES.md) — design principles, patterns, anti-patterns
+- [DOCUMENTATION_POLICY.md](DOCUMENTATION_POLICY.md) — instantiable project policy template

--- a/docs/decisions/2026-06-10-documentation-taxonomy-living-specs.md
+++ b/docs/decisions/2026-06-10-documentation-taxonomy-living-specs.md
@@ -1,0 +1,85 @@
+# ADR: Documentation Taxonomy — Living Specs, Dated Decisions, GitHub-Issue Plans
+
+**Date:** 2026-06-10
+**Status:** Accepted
+**Area:** Documentation / AI Workflow
+
+---
+
+## Context
+
+AIDE's documentation guidance grew organically and host projects show the strain. An audit of the first adopter (Lightborn Exile, issue #973) found:
+
+- **ADRs doing double duty as specs.** `/design` is hard-wired to emit an ADR, so 31 "decision records" accumulated where roughly a third are durable decisions and the rest are feature specs or already-executed work. Superseded decisions carry no machine-readable status; knowing which is live requires tribal knowledge.
+- **Transient artifacts filed as documentation.** Session handoffs, PR findings files from an abandoned review protocol, and one-shot reports sit alongside canonical truth.
+- **Pointer stubs that bounce into the submodule.** Project doc policy was a stub deferring to `.aide/docs/core/DOCUMENTATION_POLICY.md` — an extra discovery hop, and the submodule pin can drift from what the project actually does.
+- **No creation policy.** Nothing states when a contract/spec/ADR should exist, so categories were invented ad hoc (`docs/contracts/`, `docs/reports/`, `docs/review/`).
+
+The [Build-A-Better-Business/docs-template](https://github.com/Build-A-Better-Business/docs-template) repository offers a documentation kernel — a document taxonomy plus documentation principles (pointer/canonical/on-demand patterns, anti-pattern list, decision framework). AIDE has the workflow layer (skills, issue tooling, agent primers) that template lacks. The question was whether AIDE should absorb the kernel, and what taxonomy fits AIDE's model where GitHub issues — not plan documents — carry execution.
+
+## Decision
+
+AIDE absorbs a documentation kernel adapted from docs-template. AIDE defines **shapes** (taxonomy, frontmatter schemas, principles, templates); host projects own all **instances**. No project document may point into `.aide` for its substance.
+
+### Taxonomy: six homes, two flavors
+
+The dividing line is **time**, not content. A document either *claims to be current* (living — the only maintenance burden) or *records a moment* (dated — append-only, cannot drift because it does not claim currency).
+
+| Home | Question answered | Flavor |
+|---|---|---|
+| `design/` (or project equivalent) | Why does this product exist and feel this way? | Living |
+| `docs/specs/` | What is true of this system now, and what must remain true? | Living — matures with the architecture |
+| `docs/decisions/` | What did we choose that is hard to reverse, and why? | Dated, append-only |
+| GitHub epics/issues | How and when? | Executed and closed — these **are** the plans |
+| `docs/evaluations/` | What did we learn? | Dated, append-only |
+| Conventions (coding guidelines, testing policy, contributing) | How do we work? | Living |
+
+### Specs are living system documents
+
+A spec is the canonical description of a system as it exists and should exist: its model, its shape, and an explicit **Invariants** section carrying binding "what must remain true" rules (the role previously played by standalone contract documents, which fold into specs). Specs are updated as architecture matures and carry status frontmatter:
+
+```yaml
+---
+title: <system name>
+description: <one line>
+status: draft | accepted | superseded
+created: YYYY-MM-DD
+last_updated: YYYY-MM-DD
+---
+```
+
+### Creation rule (one line)
+
+> System truth → spec. Hard-to-reverse choice → ADR. Execution → issue.
+
+ADR threshold (from docs-template): real alternatives existed, the choice constrains future work, and a newcomer could accidentally reverse it. Most features never need one.
+
+### There is no plans folder
+
+Execution detail lives in GitHub epics and issues produced by `/scope` via the issue-creator tool. Plan documents are explicitly rejected: they would duplicate the issue tracker and rot.
+
+### Workflow changes
+
+- `/design` no longer emits an ADR by default. It **creates or updates the relevant system spec**, extracts a slim ADR only when the threshold is met, then hands to `/scope`.
+- `/scope` reads the spec (and ADR if present) and decomposes into issues. Unchanged otherwise.
+- Closing step of any accepted spec or executed epic that establishes new invariants: update the relevant living spec. This is how living docs stay current without a separate audit habit.
+
+### Naming
+
+- Dated records: `YYYY-MM-DD-slug.md` (retained over docs-template's `NNNN-slug` — better for small teams, no renumbering churn).
+- Living specs: `slug.md` named for the system, not the feature increment.
+
+## Rationale
+
+- **Two flavors is the solo-dev/agent maintainability answer.** The living set is the entire maintenance burden; keep it small (a handful of specs + conventions). Dated records accumulate freely without rotting.
+- **Folding contracts into specs removes a category without losing teeth.** Existing contract docs already blend system description with invariants; the Invariants section preserves binding force on the load-before-you-touch path.
+- **Specs-as-living matches docs-template intent** (RFC/superseded are *statuses* with `last_updated`; documents mature) while plans-as-issues matches AIDE's existing tooling.
+- **Shapes-vs-instances fixes pointer-stub drift.** Projects instantiate real policy files from AIDE templates instead of deferring into a submodule pin.
+
+## Consequences
+
+- AIDE gains canonical kernel docs (taxonomy + documentation principles) adapted from docs-template; `.aide/docs/core/DOCUMENTATION_POLICY.md` and the standards templates are rewritten around the taxonomy and creation rule.
+- `/design` and `/scope` skill definitions need updating (spec-first output, ADR threshold).
+- Project templates (`PROJECT_SUMMARY`, `README`, doc-policy) updated to instantiate rather than point.
+- Host projects migrate incrementally: classify existing decisions with status frontmatter in place (no mass rewrites), fold contracts into `docs/specs/`, rename `reports/` → `docs/evaluations/`, archive or delete transient artifacts.
+- First adopter migration is tracked in Lightborn Exile issue #973 and its follow-up issues.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: design
-description: Design a feature or change into a reviewed ADR. Outputs an accepted decision record ready for /scope.
+description: Design a feature or change into a reviewed system spec (plus a slim ADR only when the decision threshold is met). Outputs an accepted spec ready for /scope.
 ---
 
 # Design
 
-Produce an Architecture Decision Record (ADR) for a feature or change. Read AGENTS.md if not in context.
+Create or update the **living system spec** for a feature or change. Read AGENTS.md if not in context. Taxonomy: `.aide/docs/core/DOCUMENT_TAXONOMY.md`.
 
 ## Inputs
 
@@ -19,19 +19,35 @@ Before starting: check if `<artifact>.findings.md` exists for this topic. If it 
 
 1. **GitHub state check** — Run `gh issue list` and `gh pr list` to avoid proposing already-built or conflicting work.
 
-2. **Shape options** — Produce 1 recommended option (+ 1 alternative max). Include: pros/cons, risks, dependencies, success validation.
+2. **Locate the system spec** — Find the relevant spec in `docs/specs/` (project) or `.aide/docs/` (AIDE framework work). If none exists for this system, you will create one named for the system, not the feature.
 
-3. **Draft ADR** — Write to `.aide/docs/decisions/YYYY-MM-DD-<slug>.md` (AIDE framework decisions) or `docs/decisions/YYYY-MM-DD-<slug>.md` (game/project decisions). Status: `Draft`.
+3. **Shape options** — Produce 1 recommended option (+ 1 alternative max). Include: pros/cons, risks, dependencies, success validation.
 
-4. **Cross-review** — Use `/findings` to exchange findings before accepting. Do not accept unreviewed ADRs.
+4. **Draft** — Create or update `docs/specs/<system>.md` with frontmatter (`status: draft` for new specs). Binding rules go in the spec's **Invariants** section.
 
-5. **Accept** — Set status to `Accepted`. Hand off to `/scope` to decompose into GitHub issues.
+5. **ADR threshold check** — Also write a slim ADR to `docs/decisions/YYYY-MM-DD-<slug>.md` **only if all three hold**: real alternatives existed; the choice constrains future work; a newcomer could accidentally reverse it. The ADR points to the spec. Most features need no ADR.
 
-## ADR format
+6. **Cross-review** — Use `/findings` to exchange findings before accepting. Do not accept unreviewed specs.
+
+7. **Accept** — Set spec frontmatter `status: accepted` (and ADR status if one was written). Hand off to `/scope` to decompose into GitHub issues.
+
+## Spec frontmatter
+
+```yaml
+---
+title: <system name>
+description: <one line>
+status: draft | accepted | superseded
+created: YYYY-MM-DD
+last_updated: YYYY-MM-DD
+---
+```
+
+## ADR format (when threshold is met)
 
 ```
 # Title
-Status: Draft | Accepted | Superseded
+**Status:** Accepted (durable decision — current) | Executed (historical record) | Superseded by <file>
 ## Context
 ## Decision
 ## Rationale
@@ -40,5 +56,6 @@ Status: Draft | Accepted | Superseded
 
 ## Reference
 
+- Taxonomy + creation rule: `.aide/docs/core/DOCUMENT_TAXONOMY.md`
 - Design pillars: `design/` directory
 - Quick reference: `docs/DESIGN_QUICK_REFERENCE.md`

--- a/skills/respond/SKILL.md
+++ b/skills/respond/SKILL.md
@@ -1,35 +1,35 @@
 ---
 name: respond
-description: Apply findings from a /findings review to an ADR and write a response file
+description: Apply findings from a /findings review to a spec or ADR and write a response file
 ---
 
 # Respond
 
-Handle the designer's side of the ADR review loop. Read findings, triage them, apply agreed changes, and write a response record.
+Handle the designer's side of the spec/ADR review loop. Read findings, triage them, apply agreed changes, and write a response record.
 
-Pairs with `/findings` (reviewer writes findings) and `/design` (designer writes ADR).
+Pairs with `/findings` (reviewer writes findings) and `/design` (designer writes the spec/ADR).
 
 ## Inputs
 
-- Path to the ADR under review, or enough context to locate it
-- The findings file must already exist alongside the ADR as `<slug>.findings.md`
+- Path to the spec or ADR under review, or enough context to locate it
+- The findings file must already exist alongside it as `<slug>.findings.md`
 
 ## Workflow
 
-1. **Locate files** — Find the ADR in `docs/decisions/` or `.aide/docs/decisions/`. Look for the sibling `<slug>.findings.md`. If not found, stop and tell the user.
+1. **Locate files** — Find the artifact in `docs/specs/`, `docs/decisions/`, or `.aide/docs/`. Look for the sibling `<slug>.findings.md`. If not found, stop and tell the user.
 
-2. **Read both files** — Read the ADR and the findings file in full.
+2. **Read both files** — Read the artifact and the findings file in full.
 
 3. **Triage findings** — For each finding, decide:
-   - **Apply** — finding is correct, change the ADR
+   - **Apply** — finding is correct, change the artifact
    - **Reject** — finding is incorrect or out of scope; record reasoning
-   - **Defer** — valid but out of scope for this ADR; note where it should land
+   - **Defer** — valid but out of scope for this artifact; note where it should land
 
-4. **Apply changes** — Edit the ADR for all accepted findings. Do not change the ADR status — the reviewer (`/findings`) owns that.
+4. **Apply changes** — Edit the artifact for all accepted findings. Do not change its status — the reviewer (`/findings`) owns that.
 
-5. **Write response file** — Write `<slug>.response.md` alongside the ADR with this structure:
+5. **Write response file** — Write `<slug>.response.md` alongside the artifact with this structure:
    ```
-   # Review Response: <ADR Title>
+   # Review Response: <Title>
    ## Applied
    ## Rejected
    ## Deferred
@@ -40,5 +40,5 @@ Pairs with `/findings` (reviewer writes findings) and `/design` (designer writes
 
 ## Reference
 
-- ADR locations: `docs/decisions/` (game decisions), `.aide/docs/decisions/` (AIDE decisions)
+- Artifact locations: `docs/specs/` (living specs), `docs/decisions/` (project ADRs), `.aide/docs/decisions/` (AIDE ADRs)
 - Findings file written by: `/findings`

--- a/skills/scope/SKILL.md
+++ b/skills/scope/SKILL.md
@@ -1,19 +1,19 @@
 ---
 name: scope
-description: Decompose an accepted ADR into GitHub issues using the issue-creator tool.
+description: Decompose an accepted spec (and its ADR, if one exists) into GitHub issues using the issue-creator tool.
 ---
 
 # Scope
 
-Turn an accepted ADR into a set of GitHub issues. Read AGENTS.md if not in context.
+Turn an accepted system spec into a set of GitHub issues. Read AGENTS.md if not in context.
 
 ## Inputs
 
-Path to the accepted ADR file (or paste contents). Optionally: repo override (`owner/repo`).
+Path to the accepted spec in `docs/specs/` (or paste contents). If the design produced an ADR, read it too. Optionally: repo override (`owner/repo`).
 
 ## Workflow
 
-1. **Read ADR** — Extract: Context, Decision, Success Criteria, and any explicit scope boundaries.
+1. **Read the spec** (and ADR if present) — Extract: the change being made, Invariants affected, Success Criteria, and any explicit scope boundaries.
 
 2. **Identify work units** — Break the decision into discrete, independently deliverable chunks. Each chunk becomes one issue.
 
@@ -21,8 +21,8 @@ Path to the accepted ADR file (or paste contents). Optionally: repo override (`o
 
    ```
    ## Epic: <title>
-   Goal: <from ADR Decision>
-   ADR: <path-to-adr>
+   Goal: <from the spec's design/change section>
+   Spec: <path-to-spec>   (plus ADR path if one exists)
 
    ### Issue: <title>
    Goal: <what this chunk delivers>


### PR DESCRIPTION
## Summary

Adds an accepted ADR defining AIDE's documentation kernel, adapted from [Build-A-Better-Business/docs-template](https://github.com/Build-A-Better-Business/docs-template):

- **AIDE owns shapes, projects own instances** — no project doc may point into `.aide` for its substance
- **Six homes, two flavors** — living docs (design, specs, conventions) vs dated records (decisions, evaluations, GitHub issues)
- **Specs are living system documents** with an Invariants section (contracts fold in); plans are GitHub issues, never documents
- **Creation rule:** system truth → spec; hard-to-reverse choice → ADR; execution → issue
- `/design` becomes spec-first; ADR extracted only at the docs-template threshold

Decision settled in design discussion with project owner, 2026-06-10. First adopter migration tracked in Lightborn Exile #973.

Follow-up work (kernel docs, template rewrites, skill updates) will be scoped as separate issues per the ADR's Consequences section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)