### PR TITLE
Make plan documents an optional, project-electable pattern

### DIFF
--- a/docs/core/DOCUMENTATION_POLICY.md
+++ b/docs/core/DOCUMENTATION_POLICY.md
@@ -21,7 +21,7 @@
 
 - A **spec** (`docs/specs/<system>.md`) is the living description of a system, with status frontmatter and a binding **Invariants** section. Load it before modifying that system. When executed work changes invariants, updating the spec is part of the work.
 - An **ADR** (`docs/decisions/YYYY-MM-DD-slug.md`) is written only when real alternatives existed, the choice constrains future work, and a newcomer could accidentally reverse it.
-- **Plans are GitHub issues.** There is no plans folder. No contracts/reports/review/handoffs folders either — see the taxonomy doc for where that content lives.
+- **Plans default to GitHub issues; a `docs/plans/` execution layer is optional.** Epics/issues *are* the plans by default. A project may elect staged plan documents in its taxonomy for ordered implementation steps with validation gates; when used, a plan sequences and must not duplicate the tracker. No contracts/reports/review/handoffs folders either — see the taxonomy doc for where that content lives.
 
 ## Update Rules
 

--- a/docs/core/DOCUMENT_TAXONOMY.md
+++ b/docs/core/DOCUMENT_TAXONOMY.md
@@ -50,7 +50,7 @@ Closing step of any executed epic or accepted decision that establishes new inva
 
 ## Explicitly Rejected Categories
 
-- **No `plans/` folder.** Execution detail lives in GitHub epics and issues. Plan documents duplicate the tracker and rot.
+- **No *default* `plans/` folder.** By default, execution lives in GitHub epics/issues (they *are* the plans). Plans are **optional, not rejected**: a project may elect a `docs/plans/` execution layer in its own taxonomy for staged work with ordered steps and validation gates. When used, a plan *sequences* (it must not duplicate the issue tracker) and is closed or archived on completion.
 - **No `contracts/` folder.** Invariants live inside the relevant spec's Invariants section — on the load path, not in a separate archive.
 - **No `reports/` / `review/` / `handoffs/` folders.** Evaluations are dated records in `docs/evaluations/`; PR reviews live on GitHub; session handoffs are transient (archive or delete).
 - **No implementation-status snapshots.** Query GitHub (`gh`) for live state.

--- a/skills/design/SKILL.md
+++ b/skills/design/SKILL.md
@@ -29,7 +29,7 @@ Before starting: check if `<artifact>.findings.md` exists for this topic. If it 
 
 6. **Cross-review** — Use `/findings` to exchange findings before accepting. Do not accept unreviewed specs.
 
-7. **Accept** — Set spec frontmatter `status: accepted` (and ADR status if one was written). Hand off to `/scope` to decompose into GitHub issues.
+7. **Accept** — Set spec frontmatter `status: accepted` (and ADR status if one was written). Hand off to `/scope` to decompose into GitHub issues (or, when the project elects a `docs/plans/` layer, an optional staged plan).
 
 ## Spec frontmatter
 

--- a/skills/scope/SKILL.md
+++ b/skills/scope/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: scope
-description: Decompose an accepted spec (and its ADR, if one exists) into GitHub issues using the issue-creator tool.
+description: Decompose an accepted spec (and its ADR, if one exists) into GitHub issues — or, when the project elects a docs/plans/ layer, an optional staged plan file.
 ---
 
 # Scope
 
-Turn an accepted system spec into a set of GitHub issues. Read AGENTS.md if not in context.
+Turn an accepted system spec into independently-deliverable work units. Read AGENTS.md if not in context.
 
 ## Inputs
 
@@ -15,9 +15,13 @@ Path to the accepted spec in `docs/specs/` (or paste contents). If the design pr
 
 1. **Read the spec** (and ADR if present) — Extract: the change being made, Invariants affected, Success Criteria, and any explicit scope boundaries.
 
-2. **Identify work units** — Break the decision into discrete, independently deliverable chunks. Each chunk becomes one issue.
+2. **Identify work units** — Break the decision into discrete, independently deliverable chunks with their ordering and dependencies. Each chunk becomes one issue (issues output) or maps onto one stage (plan output).
 
-3. **Write spec file** — Create a temporary spec in issue-creator batch format:
+3. **Choose output** — **GitHub issues is the default.** Use the optional **plan output** only when the project's documentation taxonomy elects a `docs/plans/` execution layer (or the user explicitly asks for a plan). Most projects stay issues-only.
+
+### Issues output (default)
+
+4. **Write spec file** — Create a temporary spec in issue-creator batch format:
 
    ```
    ## Epic: <title>
@@ -31,14 +35,35 @@ Path to the accepted spec in `docs/specs/` (or paste contents). If the design pr
    Non-Goals: <explicit exclusions>
    ```
 
-4. **Run issue-creator** — Execute:
+5. **Run issue-creator** — Execute:
    ```
    python .aide/tools/issue-creator/issue-creator.py <spec-file>
    ```
 
-5. **Verify** — Confirm each issue was created with correct labels and GitHub Issue Type. Output issue URLs.
+6. **Verify** — Confirm each issue was created with correct labels and GitHub Issue Type. Output issue URLs.
 
-6. **Cleanup** — Delete the temporary spec file.
+7. **Cleanup** — Delete the temporary spec file.
+
+### Plan output (optional — only when the project elects a `docs/plans/` layer)
+
+4. **Write the plan** — Create `docs/plans/<slug>.md` (slug from the spec) using the project's plan frontmatter:
+
+   ```yaml
+   ---
+   title: <plan title>
+   description: One-line summary of what this plan implements
+   status: active
+   created: YYYY-MM-DD
+   last_updated: YYYY-MM-DD
+   review_status: review-required
+   spec: docs/specs/<spec>.md
+   adr: docs/adr/<nnnn-slug>.md   # omit if none
+   ---
+   ```
+
+5. **Stage the work** — The body is ordered **stages**, each with a goal, the steps to implement it, and **exit criteria / validation gates**. The work units from step 2 map onto stages in dependency order. A plan **sequences** — it must not restate the spec's design (link it) or duplicate an issue tracker.
+
+6. **Confirm** — Leave `status: active`. When executed it moves to `closed` (archive under `docs/plans/_closed/` if it keeps reference value). A stage may later be `/scope`d into issues if granular tracking is wanted.
 
 ## Reference
 


### PR DESCRIPTION
## What

Makes `docs/plans/` an **optional, project-electable** execution layer in the AIDE kernel, rather than a rejected category. Plans still default to GitHub issues; a project may elect a staged-plan layer in its own taxonomy.

## Changes

- **`docs/core/DOCUMENT_TAXONOMY.md`** — plans are optional, not rejected. By default execution lives in GitHub epics/issues; a project may elect a `docs/plans/` layer for staged work with ordered steps and validation gates. When used, a plan *sequences* (must not duplicate the tracker) and is closed/archived on completion.
- **`docs/core/DOCUMENTATION_POLICY.md`** — plans default to issues; the `docs/plans/` layer is optional and project-elected.
- **`skills/scope/SKILL.md`** — adds an optional, taxonomy-gated **plan output**. GitHub issues remain the default; plan output is used only when the project elects a `docs/plans/` layer (or the user asks).
- **`skills/design/SKILL.md`** — handoff line notes the optional plan path.

## Why

Some projects (e.g. the workflow-orchestrator) run a `docs/plans/` discipline with staged execution plans and validation gates, while others stay issues-only. This makes the kernel accommodate both without forcing either — issues-only projects are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)